### PR TITLE
Refactored random id generation + fixed small parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,12 @@ You can configure the Elastic APM agent using the following ini settings for PHP
 ```ini
 elasticapm.enable = 0
 elasticapm.host = localhost:8200
-elasticapm.service_name =
+elasticapm.service_name = "Unknown PHP service"
 elasticapm.log = 
 elasticapm.log_level= 0
 ```
 
 By default, the extension is disabled. You need to enable it setting `elasticapm.enable=1`.
-
-You need also to specify a `service_name`. The default `host` is `localhost:8200`.
 
 You can enable the logging of the PHP agent adding a file path in `elasticapm.log`.
 You can also specify the log level using the `elasticapm.log_level` key. The
@@ -82,7 +80,7 @@ following PHP code:
 
 ```php
 ini_set('elasticapm.enable', '1');
-ini_set('elasticapm.host', 'localhost:8200');
+ini_set('elasticapm.host', 'myhost:8200');
 ini_set('elasticapm.service_name', 'test');
 ini_set('elasticapm.log', '/tmp/elasticapm.log');
 ini_set('elasticapm.log_level', '4');

--- a/src/ext/php_elasticapm.h
+++ b/src/ext/php_elasticapm.h
@@ -63,7 +63,7 @@ ZEND_BEGIN_MODULE_GLOBALS(elasticapm)
 #endif
 	/* ini settings */
 	zend_bool enable;
-	char *host;
+	char *server_url;
 	char *secret_token;
 	char *service_name;
 	char *log;


### PR DESCRIPTION
This PR refactor the hex random id generation for `transaction_id`, `trace_id`, `error_id` and `exception_id` (see issue #20).

I created a static function called `static char *random_hex(int len)` that returns a random hex string of `len` characters.

Moreover, this PR includes some minor fixes like:
- check if `elasticapm.log` is not empty in order to log into a file;
- changed default `elasticapm.host` to `localhost:8200`;
- fixed the `README.md` with `php.ini` file;
- remove of `#define ZEND_INI_DISP` that was causing some warning.
