### PR TITLE
ci(jenkins): bump docker image for the CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.4-fpm
+FROM wordpress:php7.2-fpm
 
 RUN apt-get -qq update \
  && apt-get -qq install -y \


### PR DESCRIPTION
### What

Use 7.4 php version in a normal docker image

### Why

Some tests from https://github.com/elastic/apm-agent-php/pull/38 are not failing, so the `alpine` version does nothing, so let's use the default `flavor` instead


### with alpine then

```
Build complete.
Don't forget to run 'make test'.
[05-Mar-2020 10:54:53 UTC] PHP Warning:  PHP Startup: Unable to load dynamic library 'elasticapm.so' (tried: /app/src/ext/modules/elasticapm.so (Error relocating /app/src/ext/modules/elasticapm.so: php_sprintf: symbol not found), /app/src/ext/modules/elasticapm.so.so (Error loading shared library /app/src/ext/modules/elasticapm.so.so: No such file or directory)) in Unknown on line 0
[05-Mar-2020 10:54:53 UTC] PHP Warning:  PHP Startup: Unable to load dynamic library 'elasticapm.so' (tried: /app/src/ext/modules/elasticapm.so (Error relocating /app/src/ext/modules/elasticapm.so: php_sprintf: symbol not found), /app/src/ext/modules/elasticapm.so.so (Error loading shared library /app/src/ext/modules/elasticapm.so.so: No such file or directory)) in Unknown on line 0
...
Number of tests :    2                 0
Tests skipped   :    2 (100.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    0 (  0.0%) (  0.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================

```


### with default flavor then

```
Build complete.
Don't forget to run 'make test'.

Segmentation fault
Segmentation fault
Segmentation fault
...
Number of tests :    2                 2
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    2 (100.0%) (100.0%)
Tests passed    :    0 (  0.0%) (  0.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Check that elasticapm.enabled cannot be set with ini_set() [tests/enabled_setting_not_allowed.phpt]
Check if elasticapm provides transaction_id and trace_id [tests/get_current_trace_transaction_id.phpt]
=====================================================================
make: *** [Makefile:132: test] Error 1
```

### Issues

Caused by https://github.com/elastic/apm-agent-php/pull/38