### PR TITLE
Package deb/rpm/tar.gz with fpm (1st delivery)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -83,30 +83,22 @@ pipeline {
               }
             }
           }
-          stage('Install') {
+          stage('Package') {
             steps {
-              withGithubNotify(context: "Install-${PHP_VERSION}") {
+              withGithubNotify(context: "Package-${PHP_VERSION}") {
                 dir("${BASE_DIR}"){
                   sh script: "docker run --rm -t -v \$(pwd):/app test-php:${PHP_VERSION} make install", label: 'run install'
+                  sh script: "make -C packaging build package", label: 'package'
                 }
+              }
+            }
+            post {
+              always {
+                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-agent-php.*")
               }
             }
           }
         }
-      }
-    }
-    stage('Package') {
-      when {
-        beforeAgent true
-        expression { return env.ONLY_DOCS == "false" }
-      }
-      steps {
-        // TODO: This should be uncommented out when the implementation is in place
-        //withGithubNotify(context: 'Package') {
-        //  deleteDir()
-        //  unstash 'source'
-        echo 'TBD'
-        //}
       }
     }
     stage('Testing') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -83,12 +83,25 @@ pipeline {
               }
             }
           }
+          stage('Install') {
+            steps {
+              withGithubNotify(context: "Install-${PHP_VERSION}") {
+                dir("${BASE_DIR}"){
+                  sh script: "docker run --rm -t -v \$(pwd):/app test-php:${PHP_VERSION} make install", label: 'run install'
+                }
+              }
+            }
+          }
           stage('Package') {
+            // Only enable for one version to reuse the install stage output
+            when {
+              beforeAgent true
+              expression { return env.PHP_VERSION == '7.4' }
+            }
             steps {
               withGithubNotify(context: "Package-${PHP_VERSION}") {
                 dir("${BASE_DIR}"){
-                  sh script: "docker run --rm -t -v \$(pwd):/app test-php:${PHP_VERSION} make install", label: 'run install'
-                  sh script: "make -C packaging build package", label: 'package'
+                  sh script: "make -C packaging build package", label: 'packaging'
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -108,7 +108,9 @@ pipeline {
             }
             post {
               always {
-                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-agent-php*")
+                dir("${BASE_DIR}"){
+                  archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/*")
+                }
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -101,7 +101,8 @@ pipeline {
             steps {
               withGithubNotify(context: "Package-${PHP_VERSION}") {
                 dir("${BASE_DIR}"){
-                  sh script: "make -C packaging build package", label: 'packaging'
+                  sh script: "make -C packaging package", label: 'package'
+                  sh script: "make -C packaging info || true", label: 'package info'
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
             }
             post {
               always {
-                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-agent-php.*")
+                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-agent-php*")
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -96,13 +96,14 @@ pipeline {
             // Only enable for one version to reuse the install stage output
             when {
               beforeAgent true
-              expression { return env.PHP_VERSION == '7.4' }
+              expression { return env.PHP_VERSION == '7.2' }
             }
             steps {
               withGithubNotify(context: "Package-${PHP_VERSION}") {
                 dir("${BASE_DIR}"){
-                  sh script: "make -C packaging package", label: 'package'
-                  sh script: "make -C packaging info || true", label: 'package info'
+                  sh script: 'make -C packaging package', label: 'package'
+                  sh script: 'make -C packaging info', label: 'package info'
+                  sh script: 'make -C packaging deb-install', label: 'package deb-install'
                 }
               }
             }

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ phpunit.xml
 html_docs
 
 # Packaging artifacts
-*.rpm
-*.deb
+build/packages

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ phpunit.xml
 # Built documentation
 html_docs
 
+# Packaging artifacts
+*.rpm
+*.deb

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ make -C packaging deb
 
 ## To create all the packages that are supported
 make -C packaging package
+
+## To list the metadata info of the above generated packages
+make -C packaging info
+
+## To test the installation in debian
+make -C packaging deb-install
 ```
 
 _NOTE_: current implementation requires to use `make -C packaging <target>` since the workspace

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ docker run --rm -ti -v $(pwd):/app test-php make test
 docker run --rm -ti -v $(pwd):/app test-php make install
 ```
 
+To generate the packages then you can use the `packaging/Dockerfile`.
+
+```bash
+## To build the docker image that will be used later on for packaging the project
+make -C packaging build
+
+## To create the rpm package
+make -C packaging rpm
+
+## To create the deb package
+make -C packaging deb
+
+## To create all the packages that are supported
+make -C packaging package
+```
+
+_NOTE_: current implementation requires to use `make -C packaging <target>` since the workspace
+        is mounted as a volume.
+
 ## Documentation
 
 To build the documentation for this project you must first clone the [`elastic/docs` repository](https://github.com/elastic/docs/). Then run the following commands:

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.7.1-alpine3.12
+
+RUN apk add --no-cache \
+    alpine-sdk make cpio curl libarchive-tools make php-pear \
+    python3 py3-virtualenv py3-setuptools py3-pip \
+    rpm unzip xz git tar dpkg \
+  && ln -sf python3 /usr/bin/python \
+  && gem install --no-document fpm
+
+ENTRYPOINT ["fpm"]
+WORKDIR /src

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -3,6 +3,11 @@ NAME:=apm-agent-php
 VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")
 OUTPUT:=build/packages
 
+GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
+BUILD_NUMBER ?= 0
+RELEASE_TAG ?= SNAPSHOT.$(shell date '+%Y%m%d').$(BUILD_NUMBER)
+RELEASE_EPOCH ?= $(shell date '+%s')
+
 .PHONY: build
 build:
 	@docker build -t $(IMAGE) .
@@ -16,6 +21,8 @@ create-%: build
 		--input-type dir \
 		--output-type $* \
 		--name $(NAME) \
+		--iteration "$(RELEASE_TAG)" \
+		--epoch "$(RELEASE_EPOCH)" \
 		--version $(VERSION) \
 		--architecture all \
 		--url 'TBD' \
@@ -23,6 +30,7 @@ create-%: build
 		--description 'TBD' \
 		--license 'TBD' \
 		--vendor 'elastic' \
+		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \
 		--package $(OUTPUT) \
 		--chdir /app \
 		src/ext/modules/=/usr/share/php/extensions \
@@ -57,13 +65,17 @@ info: rpm-info deb-info
 
 .PHONY: rpm-info
 rpm-info:
-	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
-	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
+	@cd $(PWD) ;\
+	BINARY=$$(ls -1 $(OUTPUT)/*.rpm) ;\
+	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $$BINARY ;\
+	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $$BINARY
 
 .PHONY: deb-info
 deb-info:
-	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
-	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
+	@cd $(PWD) ;\
+	BINARY=$$(ls -1 $(OUTPUT)/*.deb) ;\
+	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $$BINARY ;\
+	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $$BINARY
 
 .PHONY: rpm-install
 rpm-install:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,6 +1,6 @@
 IMAGE:=php-packaging
 NAME:=apm-agent-php
-VERSION:=2.10
+VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")
 
 .PHONY: build
 build:
@@ -8,7 +8,7 @@ build:
 
 create-%:
 	docker run --rm -ti \
-		-v $(PWD)/..:/app \
+		-v $(PWD):/app \
 		-w /app $(IMAGE) \
 		-s dir \
 		-t $* \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -37,6 +37,7 @@ create-%: build
 
 .PHONY: rpm
 rpm: create-rpm
+	## TODO: fpm replaces - with _ in the version
 
 .PHONY: deb
 deb: create-deb

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -27,7 +27,6 @@ create-%: build
 		--architecture all \
 		--url 'TBD' \
 		--maintainer 'elastic' \
-		--description 'TBD' \
 		--license 'TBD' \
 		--vendor 'elastic' \
 		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \
@@ -83,10 +82,7 @@ rpm-install:
 
 .PHONY: deb-install
 deb-install:
-	@docker build -t deb-install -f $(PWD)/packaging/test/ubuntu/Dockerfile . > /dev/null
-	@echo 'Connecting to the docker ubuntu container... type the below commands'
-	@echo 'dpkg -i build/packages/*.deb'
-	@echo 'cp /usr/share/php/extensions/elastic_apm.so   /usr/local/lib/php/extensions/no-debug-non-zts-20190902/'
-	@echo 'php-fpm'
-	@echo ''
-	@docker run --rm -ti -v $(PWD):/src -w /src deb-install /bin/bash
+	@cd $(PWD)/packaging/test/ubuntu ;\
+	docker build -t deb-install . ;\
+	cd -
+	@docker run --rm -v $(PWD):/src -w /src deb-install

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -7,6 +7,7 @@ build:
 	docker build -t $(IMAGE) .
 
 create-%:
+	mkdir -p $(PWD)/build/packages || true
 	docker run --rm \
 		-v $(PWD):/app \
 		-w /app $(IMAGE) \
@@ -19,7 +20,12 @@ create-%:
 		--description 'TBD' \
 		--license 'TBD' \
 		--vendor 'elastic' \
-		-C /app/src/ext/modules
+		-p build/packages \
+		-C /app \
+		src/ext/modules/=/usr/share/php/extensions \
+		README.md=/usr/share/doc/apm-agent-php/docs/README.md \
+		src/ElasticApm=/usr/share/php/apm-agent-php \
+		src/bootstrap_php_part.php=/usr/share/php/apm-agent-php/bootstrap_php_part.php
 
 .PHONY: rpm
 rpm: create-rpm
@@ -27,20 +33,25 @@ rpm: create-rpm
 .PHONY: deb
 deb: create-deb
 
+.PHONY: tar
+tar: create-tar
+
 .PHONY: version
 version:
 	docker run --rm -ti $(IMAGE) --version
 
 .PHONY: package
-package: rpm deb
+package: rpm deb tar
 
 .PHONY: rpm-info
 rpm-info:
-	docker run --rm -ti -v $(PWD)/..:/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(NAME)-$(VERSION)-1.x86_64.rpm
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(NAME)-$(VERSION)-1.x86_64.rpm
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(NAME)-$(VERSION)-1.x86_64.rpm
 
 .PHONY: deb-info
 deb-info:
-	docker run --rm -ti -v $(PWD)/..:/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(NAME)_$(VERSION)_amd64.deb
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(NAME)_$(VERSION)_amd64.deb
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(NAME)_$(VERSION)_amd64.deb
 
 .PHONY: rpm-install
 rpm-install:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -7,7 +7,7 @@ OUTPUT:=build/packages
 build:
 	@docker build -t $(IMAGE) .
 
-create-%:
+create-%: build
 	@mkdir -p $(PWD)/$(OUTPUT)
 	@docker run --rm \
 		-v $(PWD):/app \
@@ -44,6 +44,9 @@ version:
 
 .PHONY: package
 package: rpm deb tar
+
+.PHONY: info
+info: rpm-info deb-info
 
 .PHONY: rpm-info
 rpm-info:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -7,7 +7,7 @@ build:
 	docker build -t $(IMAGE) .
 
 create-%:
-	docker run --rm -ti \
+	docker run --rm \
 		-v $(PWD):/app \
 		-w /app $(IMAGE) \
 		-s dir \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -21,7 +21,7 @@ create-%: build
 		--version $(VERSION) \
 		--architecture all \
 		--url 'https://github.com/elastic/apm-agent-php' \
-		--maintainer 'APM Team <info@elastic.co>', \
+		--maintainer 'APM Team <info@elastic.co>' \
 		--license 'ASL 2.0' \
 		--vendor 'Elasticsearch, Inc.' \
 		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -5,11 +5,11 @@ OUTPUT:=build/packages
 
 .PHONY: build
 build:
-	docker build -t $(IMAGE) .
+	@docker build -t $(IMAGE) .
 
 create-%:
-	mkdir -p $(PWD)/$(OUTPUT)
-	docker run --rm \
+	@mkdir -p $(PWD)/$(OUTPUT)
+	@docker run --rm \
 		-v $(PWD):/app \
 		-w /app $(IMAGE) \
 		--input-type dir \
@@ -40,20 +40,20 @@ tar: create-tar
 
 .PHONY: version
 version:
-	docker run --rm -ti $(IMAGE) --version
+	@docker run --rm -ti $(IMAGE) --version
 
 .PHONY: package
 package: rpm deb tar
 
 .PHONY: rpm-info
 rpm-info:
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.x86_64.rpm
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.x86_64.rpm
+	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
+	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
 
 .PHONY: deb-info
 deb-info:
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)-amd64.deb
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)-amd64.deb
+	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
+	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
 
 .PHONY: rpm-install
 rpm-install:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -8,6 +8,7 @@ build:
 	@docker build -t $(IMAGE) .
 
 create-%: build
+	@echo 'Creating package ...'
 	@mkdir -p $(PWD)/$(OUTPUT)
 	@docker run --rm \
 		-v $(PWD):/app \
@@ -28,6 +29,11 @@ create-%: build
 		README.md=/usr/share/doc/apm-agent-php/docs/README.md \
 		src/ElasticApm=/usr/share/php/apm-agent-php \
 		src/bootstrap_php_part.php=/usr/share/php/apm-agent-php/bootstrap_php_part.php
+	@echo 'Creating sha512sum ...'
+	@BINARY=$$(ls -1 $(PWD)/$(OUTPUT)/*.$*) ;\
+	sha512sum $$BINARY > $$BINARY.sha512 ;\
+	sed -i.bck "s#$(PWD)/$(OUTPUT)/##g" $$BINARY.sha512 ;\
+	rm $(PWD)/$(OUTPUT)/*.bck
 
 .PHONY: rpm
 rpm: create-rpm

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,27 +1,29 @@
 IMAGE:=php-packaging
 NAME:=apm-agent-php
 VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")
+OUTPUT:=build/packages
 
 .PHONY: build
 build:
 	docker build -t $(IMAGE) .
 
 create-%:
-	mkdir -p $(PWD)/build/packages || true
+	mkdir -p $(PWD)/$(OUTPUT)
 	docker run --rm \
 		-v $(PWD):/app \
 		-w /app $(IMAGE) \
-		-s dir \
-		-t $* \
-		-n $(NAME) \
-		-v $(VERSION) \
+		--input-type dir \
+		--output-type $* \
+		--name $(NAME) \
+		--version $(VERSION) \
+		--architecture all \
 		--url 'TBD' \
 		--maintainer 'elastic' \
 		--description 'TBD' \
 		--license 'TBD' \
 		--vendor 'elastic' \
-		-p build/packages \
-		-C /app \
+		--package $(OUTPUT) \
+		--chdir /app \
 		src/ext/modules/=/usr/share/php/extensions \
 		README.md=/usr/share/doc/apm-agent-php/docs/README.md \
 		src/ElasticApm=/usr/share/php/apm-agent-php \
@@ -45,13 +47,13 @@ package: rpm deb tar
 
 .PHONY: rpm-info
 rpm-info:
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(NAME)-$(VERSION)-1.x86_64.rpm
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(NAME)-$(VERSION)-1.x86_64.rpm
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.x86_64.rpm
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.x86_64.rpm
 
 .PHONY: deb-info
 deb-info:
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(NAME)_$(VERSION)_amd64.deb
-	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(NAME)_$(VERSION)_amd64.deb
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)-amd64.deb
+	docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)-amd64.deb
 
 .PHONY: rpm-install
 rpm-install:
@@ -59,4 +61,10 @@ rpm-install:
 
 .PHONY: deb-install
 deb-install:
-	echo 'TBD'
+	@docker build -t deb-install -f $(PWD)/packaging/test/ubuntu/Dockerfile . > /dev/null
+	@echo 'Connecting to the docker ubuntu container... type the below commands'
+	@echo 'dpkg -i build/packages/*.deb'
+	@echo 'cp /usr/share/php/extensions/elastic_apm.so   /usr/local/lib/php/extensions/no-debug-non-zts-20190902/'
+	@echo 'php-fpm'
+	@echo ''
+	@docker run --rm -ti -v $(PWD):/src -w /src deb-install /bin/bash

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,0 +1,51 @@
+IMAGE:=php-packaging
+NAME:=apm-agent-php
+VERSION:=2.10
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .
+
+create-%:
+	docker run --rm -ti \
+		-v $(PWD)/..:/app \
+		-w /app $(IMAGE) \
+		-s dir \
+		-t $* \
+		-n $(NAME) \
+		-v $(VERSION) \
+		--url 'TBD' \
+		--maintainer 'elastic' \
+		--description 'TBD' \
+		--license 'TBD' \
+		--vendor 'elastic' \
+		-C /app/src/ext/modules
+
+.PHONY: rpm
+rpm: create-rpm
+
+.PHONY: deb
+deb: create-deb
+
+.PHONY: version
+version:
+	docker run --rm -ti $(IMAGE) --version
+
+.PHONY: package
+package: rpm deb
+
+.PHONY: rpm-info
+rpm-info:
+	docker run --rm -ti -v $(PWD)/..:/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(NAME)-$(VERSION)-1.x86_64.rpm
+
+.PHONY: deb-info
+deb-info:
+	docker run --rm -ti -v $(PWD)/..:/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(NAME)_$(VERSION)_amd64.deb
+
+.PHONY: rpm-install
+rpm-install:
+	echo 'TBD'
+
+.PHONY: deb-install
+deb-install:
+	echo 'TBD'

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -47,7 +47,7 @@ tar: create-tar
 
 .PHONY: version
 version:
-	@docker run --rm -ti $(IMAGE) --version
+	@docker run --rm $(IMAGE) --version
 
 .PHONY: package
 package: rpm deb tar
@@ -57,13 +57,13 @@ info: rpm-info deb-info
 
 .PHONY: rpm-info
 rpm-info:
-	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
-	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
+	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
+	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $(OUTPUT)/$(NAME)-$(VERSION)-1.noarch.rpm
 
 .PHONY: deb-info
 deb-info:
-	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
-	@docker run --rm -ti -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
+	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
+	@docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $(OUTPUT)/$(NAME)_$(VERSION)_all.deb
 
 .PHONY: rpm-install
 rpm-install:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -4,9 +4,6 @@ VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 |
 OUTPUT:=build/packages
 
 GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
-BUILD_NUMBER ?= 0
-RELEASE_TAG ?= SNAPSHOT.$(shell date '+%Y%m%d').$(BUILD_NUMBER)
-RELEASE_EPOCH ?= $(shell date '+%s')
 
 .PHONY: build
 build:
@@ -21,14 +18,12 @@ create-%: build
 		--input-type dir \
 		--output-type $* \
 		--name $(NAME) \
-		--iteration "$(RELEASE_TAG)" \
-		--epoch "$(RELEASE_EPOCH)" \
 		--version $(VERSION) \
 		--architecture all \
-		--url 'TBD' \
-		--maintainer 'elastic' \
-		--license 'TBD' \
-		--vendor 'elastic' \
+		--url 'https://github.com/elastic/apm-agent-php' \
+		--maintainer 'APM Team <info@elastic.co>', \
+		--license 'ASL 2.0' \
+		--vendor 'Elasticsearch, Inc.' \
 		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \
 		--package $(OUTPUT) \
 		--chdir /app \

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,21 +1,3 @@
 This folder contains all the recipes to generate a package for different systems, such as debian, centos and so on.
 
 For such it uses [FPM](https://github.com/jordansissel/fpm/wiki)
-
-## How to use it 
-
-
-```bash
-## To build the docker image that will be used later on for packaging the project
-make build
-
-## To create the rpm package
-make rpm
-
-## To create the deb package
-make deb
-
-## To create all the packages that are supported
-make package
-
-```

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,21 @@
+This folder contains all the recipes to generate a package for different systems, such as debian, centos and so on.
+
+For such it uses [FPM](https://github.com/jordansissel/fpm/wiki)
+
+## How to use it 
+
+
+```bash
+## To build the docker image that will be used later on for packaging the project
+make build
+
+## To create the rpm package
+make rpm
+
+## To create the deb package
+make deb
+
+## To create all the packages that are supported
+make package
+
+```

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -1,0 +1,5 @@
+ARG PHP_VERSION=7.4
+FROM wordpress:php${PHP_VERSION}-fpm
+WORKDIR /src
+RUN echo 'extension=elastic_apm.so' > /usr/local/etc/php/php.ini
+RUN echo 'elastic_apm.bootstrap_php_part_file=/usr/share/php/apm-agent-php/bootstrap_php_part.php' >> /usr/local/etc/php/php.ini

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -1,5 +1,17 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=7.2
 FROM wordpress:php${PHP_VERSION}-fpm
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && php -r "if (hash_file('sha384', 'composer-setup.php') === 'e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+ && php composer-setup.php --install-dir=/usr/bin --filename=composer \
+ && php -r "unlink('composer-setup.php');"
+
+# sh: 1: ps: not found
+RUN apt-get -qq update \
+ && apt-get -qq install -y procps --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /bin
 WORKDIR /src
-RUN echo 'extension=elastic_apm.so' > /usr/local/etc/php/php.ini
-RUN echo 'elastic_apm.bootstrap_php_part_file=/usr/share/php/apm-agent-php/bootstrap_php_part.php' >> /usr/local/etc/php/php.ini
+
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -x
+
+## Install debian package and configure the agent accordingly
+
+## TODO, php.ini setup to be done by the deb package.
+echo 'extension=elastic_apm.so' > /usr/local/etc/php/php.ini
+echo 'elastic_apm.bootstrap_php_part_file=/usr/share/php/apm-agent-php/bootstrap_php_part.php' >> /usr/local/etc/php/php.ini
+dpkg -i build/packages/*.deb
+cp /usr/share/php/extensions/elastic_apm.so /usr/local/lib/php/extensions/no-debug-non-zts-20170718/
+php -m
+
+## Validate the installation works as expected with composer
+composer install
+composer run-script run_component_tests_standalone_envs


### PR DESCRIPTION
### What

- The very first iteration to build the rpm/deb/tgz packages with [fpm](https://fpm.readthedocs.io/en/latest/intro.html)
- Create sha512.
- Delegate the package generation with a docker container and specific goals in make.
- Add smoke tests to validate the package generations works as expected from the installation point of view to the agent point of view.
- Archive packages in the CI pipeline.
- Support `7.2` php versioning for the time being.
- There will be further follow-ups as stated in https://github.com/elastic/apm-agent-php/issues/72

### Tests

- rpm/deb packages generated within the pipeline -> [here](https://apm-ci.elastic.co/job/apm-agent-php/job/apm-agent-php-mbp/job/PR-79/5/artifact/src/go.elastic.co/apm/apm-agent-php/)

#### deb package

```bash
$ VERSION=0.0.1 make -C packaging deb deb-info
mkdir -p /Users/vmartinez/work/src/github.com/elastic/apm-agent-php/build/packages
Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
Require just the needed backports instead, or 'backports/latest'.
{:timestamp=>"2020-07-15T21:09:47.459435+0000", :message=>"Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag", :level=>:warn}
{:timestamp=>"2020-07-15T21:09:47.699993+0000", :message=>"Created package", :path=>"build/packages/apm-agent-php_0.0.1_all.deb"}
 new Debian package, version 2.0.
 size 885494 bytes: control archive=3789 bytes.
     190 bytes,    11 lines      control              
   11571 bytes,   113 lines      md5sums              
 Package: apm-agent-php
 Version: 0.0.1
 License: TBD
 Vendor: elastic
 Architecture: all
 Maintainer: elastic
 Installed-Size: 3143
 Section: default
 Priority: extra
 Homepage: TBD
 Description: TBD
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./usr/
...
-rw-r--r-- 0/0             983 2020-07-07 08:23 ./usr/share/php/apm-agent-php/ElasticApm/TransactionDataInterface.php
-rw-r--r-- 0/0             230 2020-07-07 08:23 ./usr/share/php/apm-agent-php/bootstrap_php_part.php
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./usr/share/php/extensions/
-rwxr-xr-x 0/0         3029336 2020-07-15 19:42 ./usr/share/php/extensions/elastic_apm.so
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./usr/share/doc/
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./usr/share/doc/apm-agent-php/
drwxr-xr-x 0/0               0 2020-07-15 21:09 ./usr/share/doc/apm-agent-php/docs/
-rw-r--r-- 0/0            2483 2020-07-08 10:50 ./usr/share/doc/apm-agent-php/docs/README.md
-rw-r--r-- 0/0             131 2020-07-15 21:09 ./usr/share/doc/apm-agent-php/changelog.gz
```
#### rpm package

```bash
$ VERSION=0.0.1 make -C packaging rpm rpm-info
Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
Require just the needed backports instead, or 'backports/latest'.
{:timestamp=>"2020-07-15T21:11:34.133733+0000", :message=>"Created package", :path=>"build/packages/apm-agent-php-0.0.1-1.noarch.rpm"}
Name        : apm-agent-php
Version     : 0.0.1
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : default
Size        : 3219301
License     : TBD
Signature   : (none)
Source RPM  : apm-agent-php-0.0.1-1.src.rpm
Build Date  : Wed Jul 15 21:11:33 2020
Build Host  : a241b93b070a
Relocations : / 
Packager    : elastic
Vendor      : elastic
URL         : TBD
Summary     : TBD
Description :
TBD
/usr/share/doc/apm-agent-php/docs/README.md
/usr/share/php/apm-agent-php/ElasticApm/AutoInstrument/InterceptedCallTrackerInterface.php
/usr/share/php/apm-agent-php/ElasticApm/AutoInstrument/PluginInterface.php
/usr/share/php/apm-agent-php/ElasticApm/AutoInstrument/RegistrationContextInterface.php
/usr/share/php/apm-agent-php/ElasticApm/ContextDataInterface.php
/usr/share/php/apm-agent-php/ElasticApm/ContextRequestDataInterface.php
/usr/share/php/apm-agent-php/ElasticApm/ElasticApm.php
```

#### deb package installation

```bash
$ make -C packaging deb-install 
...
+ php -m
[PHP Modules]
...
elastic_apm
...

OK (3 tests, 65 assertions)
> ELASTIC_APM_TESTS_APP_CODE_HOST_KIND=CLI_builtin_HTTP_server phpunit -c phpunit_component_tests.xml
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.31
Configuration: /src/phpunit_component_tests.xml

...                                                                 3 / 3 (100%)

Time: 5.31 seconds, Memory: 10.00 MB

OK (3 tests, 65 assertions)
```

### Further reading

- [debian-versioning-format](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version) 