### PR TITLE
Docs: add help make goal and enhance the docs

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -4,14 +4,19 @@ PHP_VERSION ?= 7.2
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
+.PHONY: help
+.DEFAULT_GOAL := help
+help: ## Display this help text
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: prepare
-prepare:
+prepare:  ## Build docker image for building and testing the project
 	docker build \
 		--build-arg PHP_VERSION=${PHP_VERSION} \
 		--tag $(IMAGE):${PHP_VERSION} .
 
 .PHONY: build
-build: prepare
+build: prepare  ## Build the project
 	# docker as the current user
 	docker run --rm -t \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
@@ -19,7 +24,7 @@ build: prepare
 		$(IMAGE):${PHP_VERSION}
 
 .PHONY: test
-test: prepare
+test: prepare  ## Test the project
 	# docker as the current user
 	docker run --rm -t \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
@@ -28,7 +33,7 @@ test: prepare
 		make test
 
 .PHONY: install
-install: prepare
+install: prepare  ## Install the agent
 	# docker as root to install the extension
 	docker run --rm -t \
 		-v $(PWD):/app \
@@ -36,7 +41,7 @@ install: prepare
 		make install
 
 .PHONY: composer
-composer: prepare
+composer: prepare  ## Run composer
 	# docker as root to install the extension
 	docker run -t --rm \
 		-v $(PWD):/app \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ PHP_VERSION=7.2 make -f .ci/Makefile install
 
 ## To install with composer
 PHP_VERSION=7.2 make -f .ci/Makefile composer
+
+## Help goal will provide further details
+make -f .ci/Makefile help
 ```
 
 _NOTE_: `PHP_VERSION` can be set to a different PHP version.
@@ -66,6 +69,9 @@ make -C packaging info
 
 ## To test the installation in debian
 make -C packaging deb-install
+
+## Help goal will provide further details
+make -C packaging help
 ```
 
 _NOTE_: current implementation requires to use `make -C packaging <target>` since the workspace

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -5,11 +5,16 @@ OUTPUT:=build/packages
 
 GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
 
+.PHONY: help
+.DEFAULT_GOAL := help
+help: ## Display this help text
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: build
-build:
+build: ## Build docker image for the packaging
 	@docker build -t $(IMAGE) .
 
-create-%: build
+create-%: build  ## Create the specific package
 	@echo 'Creating package ...'
 	@mkdir -p $(PWD)/$(OUTPUT)
 	@docker run --rm \
@@ -38,45 +43,45 @@ create-%: build
 	rm $(PWD)/$(OUTPUT)/*.bck
 
 .PHONY: rpm
-rpm: create-rpm
+rpm: create-rpm  ## Create the rpm installer
 	## TODO: fpm replaces - with _ in the version
 
 .PHONY: deb
-deb: create-deb
+deb: create-deb  ## Create the deb installer
 
 .PHONY: tar
-tar: create-tar
+tar: create-tar  ## Create the tar.gz
 
 .PHONY: version
-version:
+version:  ## Show the fpm version
 	@docker run --rm $(IMAGE) --version
 
 .PHONY: package
-package: rpm deb tar
+package: rpm deb tar  ## Create all the installers
 
 .PHONY: info
-info: rpm-info deb-info
+info: rpm-info deb-info  ## Show the package metadata for all the installers
 
 .PHONY: rpm-info
-rpm-info:
+rpm-info:  ## Show the rpm package metadata
 	@cd $(PWD) ;\
 	BINARY=$$(ls -1 $(OUTPUT)/*.rpm) ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $$BINARY ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $$BINARY
 
 .PHONY: deb-info
-deb-info:
+deb-info:  ## Show the deb package metadata
 	@cd $(PWD) ;\
 	BINARY=$$(ls -1 $(OUTPUT)/*.deb) ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $$BINARY ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $$BINARY
 
 .PHONY: rpm-install
-rpm-install:
+rpm-install:  ## Install the rpm installer to run some smoke tests
 	echo 'TBD'
 
 .PHONY: deb-install
-deb-install:
+deb-install:  ## Install the deb installer to run some smoke tests
 	@cd $(PWD)/packaging/test/ubuntu ;\
 	docker build -t deb-install . ;\
 	cd -


### PR DESCRIPTION
This will help to show what each make goal does

## UI

```
$ make -f .ci/Makefile
build                Build the project
composer             Run composer
help                 Display this help text
install              Install the agent
prepare              Build docker image for building and testing the project
test                 Test the project

$ make -C packaging help
build                Build docker image for the packaging
deb-info             Show the deb package metadata
deb-install          Install the deb installer to run some smoke tests
deb                  Create the deb installer
help                 Display this help text
info                 Show the package metadata for all the installers
package              Create all the installers
rpm-info             Show the rpm package metadata
rpm-install          Install the rpm installer to run some smoke tests
rpm                  Create the rpm installer
tar                  Create the tar.gz
version              Show the fpm version
```