### PR TITLE
packaging: debian package installation with post-install

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -103,17 +103,12 @@ pipeline {
             }
           }
           stage('Package') {
-            // Only enable for one version to reuse the install stage output
-            when {
-              beforeAgent true
-              expression { return env.PHP_VERSION == '7.2' }
-            }
             steps {
               withGithubNotify(context: "Package-${PHP_VERSION}") {
                 dir("${BASE_DIR}"){
-                  sh script: 'make -C packaging package', label: 'package'
-                  sh script: 'make -C packaging info', label: 'package info'
-                  sh script: 'make -C packaging deb-install', label: 'package deb-install'
+                  sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging package", label: 'package'
+                  sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging info", label: 'package info'
+                  sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging deb-install", label: 'package deb-install'
                 }
               }
             }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,8 +34,8 @@ To generate the packages then you can use the `packaging/Dockerfile`, see the be
 | --- |
 
 ```bash
-## To build the docker image that will be used later on for packaging the project
-make -C packaging build
+## To prepare the docker image that will be used later on for packaging the project
+make -C packaging prepare
 
 ## To create the rpm package
 make -C packaging rpm

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -3,6 +3,7 @@ NAME:=apm-agent-php
 VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")
 OUTPUT:=build/packages
 PHP_AGENT_DIR:=/opt/elastic/apm-agent-php
+PHP_VERSION?=7.2
 GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
 
 .PHONY: help
@@ -85,6 +86,6 @@ rpm-install:  ## Install the rpm installer to run some smoke tests
 .PHONY: deb-install
 deb-install:  ## Install the deb installer to run some smoke tests
 	@cd $(PWD)/packaging/test/ubuntu ;\
-	docker build -t deb-install . ;\
+	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t deb-install . ;\
 	cd -
 	@docker run --rm -v $(PWD):/src -w /src deb-install

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -11,11 +11,11 @@ GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
 help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build
-build: ## Build docker image for the packaging
+.PHONY: prepare
+prepare: ## Build docker image for the packaging
 	@docker build -t $(IMAGE) .
 
-create-%: build  ## Create the specific package
+create-%: prepare  ## Create the specific package
 	@echo 'Creating package ...'
 	@mkdir -p $(PWD)/$(OUTPUT)
 	@docker run --rm \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -2,7 +2,7 @@ IMAGE:=php-packaging
 NAME:=apm-agent-php
 VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")
 OUTPUT:=build/packages
-
+PHP_AGENT_DIR:=/opt/elastic/apm-agent-php
 GIT_SHA ?= $(shell git rev-parse HEAD || echo "unknown")
 
 .PHONY: help
@@ -32,10 +32,12 @@ create-%: build  ## Create the specific package
 		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \
 		--package $(OUTPUT) \
 		--chdir /app \
-		src/ext/modules/=/usr/share/php/extensions \
-		README.md=/usr/share/doc/apm-agent-php/docs/README.md \
-		src/ElasticApm=/usr/share/php/apm-agent-php \
-		src/bootstrap_php_part.php=/usr/share/php/apm-agent-php/bootstrap_php_part.php
+		--after-install=packaging/post-install.sh \
+		packaging/post-install.sh=$(PHP_AGENT_DIR)/bin/post-install.sh \
+		src/ext/modules/=$(PHP_AGENT_DIR)/extensions \
+		README.md=$(PHP_AGENT_DIR)/docs/README.md \
+		src/ElasticApm=$(PHP_AGENT_DIR)/src \
+		src/bootstrap_php_part.php=$(PHP_AGENT_DIR)/src/bootstrap_php_part.php
 	@echo 'Creating sha512sum ...'
 	@BINARY=$$(ls -1 $(PWD)/$(OUTPUT)/*.$*) ;\
 	sha512sum $$BINARY > $$BINARY.sha512 ;\

--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-###########
-# GLOBALS #
-###########
+################################################################################
+############################ GLOBAL VARIABLES ##################################
+################################################################################
 PHP_AGENT_DIR=/opt/elastic/apm-agent-php
 EXTENSION_FILE_PATH="${PHP_AGENT_DIR}/extensions/elastic_apm.so"
 BOOTSTRAP_FILE_PATH="${PHP_AGENT_DIR}/src/bootstrap_php_part.php"
@@ -12,10 +12,16 @@ BOOTSTRAP_FILE_PATH="${PHP_AGENT_DIR}/src/bootstrap_php_part.php"
 ################################################################################
 
 ################################################################################
-#### Function php_ini_path #####################################################
-function php_ini_path() {
+#### Function php_command ######################################################
+function php_command() {
     PHP_BIN=$(command -v php)
-    ${PHP_BIN} -d memory_limit=128M -i \
+    ${PHP_BIN} -d memory_limit=128M "$@"
+}
+
+################################################################################
+#### Function php_ini_file_path ################################################
+function php_ini_file_path() {
+    php_command -i \
         | grep 'Configuration File (php.ini) Path =>' \
         | sed -e 's#Configuration File (php.ini) Path =>##g' \
         | head -n 1 \
@@ -23,9 +29,14 @@ function php_ini_path() {
 }
 
 ################################################################################
+#### Function is_extension_installed ###########################################
+function is_extension_installed() {
+    php_command -m | grep -q 'elastic'
+}
+
+################################################################################
 #### Function add_extension_configuration_to_file ##############################
 function add_extension_configuration_to_file() {
-    echo '  Extension configuration has just been added for the Elastic PHP agent.'
     tee -a "$@" <<EOF
 ; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
 extension=${EXTENSION_FILE_PATH}
@@ -38,14 +49,22 @@ EOF
 ############################### MAIN ###########################################
 ################################################################################
 echo 'Installing Elastic PHP agent'
-PHP_INI_FILE="$(php_ini_path)/php.ini"
-if [ -e "${PHP_INI_FILE}" ] ; then
-    if grep -q "${EXTENSION_FILE_PATH}" "${PHP_INI_FILE}" ; then
+PHP_INI_FILE_PATH="$(php_ini_file_path)/php.ini"
+if [ -e "${PHP_INI_FILE_PATH}" ] ; then
+    if grep -q "${EXTENSION_FILE_PATH}" "${PHP_INI_FILE_PATH}" ; then
         echo '  extension configuration already exists for the Elastic PHP agent.'
         echo '  skipping ... '
     else
-        add_extension_configuration_to_file "${PHP_INI_FILE}"
+        add_extension_configuration_to_file "${PHP_INI_FILE_PATH}"
     fi
 else
-    add_extension_configuration_to_file "${PHP_INI_FILE}"
+    add_extension_configuration_to_file "${PHP_INI_FILE_PATH}"
+fi
+
+if is_extension_installed ; then
+    echo 'Extension enabled successfully for Elastic PHP agent'
+else
+    echo 'Failed enabling Elastic PHP agent extension'
+    echo 'Set up the Agent manually as explained in:'
+    echo 'https://github.com/elastic/apm-agent-php/blob/master/docs/setup.asciidoc'
 fi

--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+###########
+# GLOBALS #
+###########
+PHP_AGENT_DIR=/opt/elastic/apm-agent-php
+EXTENSION_FILE_PATH="${PHP_AGENT_DIR}/extensions/elastic_apm.so"
+BOOTSTRAP_FILE_PATH="${PHP_AGENT_DIR}/src/bootstrap_php_part.php"
+
+################################################################################
+########################## FUNCTION CALLS BELOW ################################
+################################################################################
+
+################################################################################
+#### Function php_ini_path #####################################################
+function php_ini_path() {
+    PHP_BIN=$(command -v php)
+    ${PHP_BIN} -d memory_limit=128M -i \
+        | grep 'Configuration File (php.ini) Path =>' \
+        | sed -e 's#Configuration File (php.ini) Path =>##g' \
+        | head -n 1 \
+        | awk '{print $1}'
+}
+
+################################################################################
+#### Function add_extension_configuration_to_file ##############################
+function add_extension_configuration_to_file() {
+    echo '  Extension configuration has just been added for the Elastic PHP agent.'
+    tee -a "$@" <<EOF
+; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
+extension=${EXTENSION_FILE_PATH}
+elastic_apm.bootstrap_php_part_file=${BOOTSTRAP_FILE_PATH}
+; END OF AUTO-GENERATED
+EOF
+}
+
+################################################################################
+############################### MAIN ###########################################
+################################################################################
+echo 'Installing Elastic PHP agent'
+PHP_INI_FILE="$(php_ini_path)/php.ini"
+if [ -e "${PHP_INI_FILE}" ] ; then
+    if grep -q "${EXTENSION_FILE_PATH}" "${PHP_INI_FILE}" ; then
+        echo '  extension configuration already exists for the Elastic PHP agent.'
+        echo '  skipping ... '
+    else
+        add_extension_configuration_to_file "${PHP_INI_FILE}"
+    fi
+else
+    add_extension_configuration_to_file "${PHP_INI_FILE}"
+fi

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=7.2
-FROM wordpress:php${PHP_VERSION}-fpm
+FROM php:${PHP_VERSION}-fpm
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
  && php -r "if (hash_file('sha384', 'composer-setup.php') === 'e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -2,13 +2,13 @@
 set -x
 
 ## Install debian package and configure the agent accordingly
-
-## TODO, php.ini setup to be done by the deb package.
-echo 'extension=elastic_apm.so' > /usr/local/etc/php/php.ini
-echo 'elastic_apm.bootstrap_php_part_file=/usr/share/php/apm-agent-php/bootstrap_php_part.php' >> /usr/local/etc/php/php.ini
 dpkg -i build/packages/*.deb
-cp /usr/share/php/extensions/elastic_apm.so /usr/local/lib/php/extensions/no-debug-non-zts-20170718/
-php -m
+
+## Verify if the elastic php agent is enabled
+if ! php -m | grep 'elastic' ; then
+    echo 'Extension has not been installed.'
+    exit 1
+fi
 
 ## Validate the installation works as expected with composer
 composer install

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -5,7 +5,7 @@ set -x
 dpkg -i build/packages/*.deb
 
 ## Verify if the elastic php agent is enabled
-if ! php -m | grep 'elastic' ; then
+if ! php -m | grep -q 'elastic' ; then
     echo 'Extension has not been installed.'
     exit 1
 fi


### PR DESCRIPTION
### What

- Configure the debian package installation with the post-install.sh script.
- Agent installed in the path `/opt/elastic/apm-agent-php`
- Use the official [`php-fpm`](https://hub.docker.com/_/php) docker image.
- Installation test script uses the installer rather than the hardcoded configuration.
- Support for different php versions by command line.
- Support packaging and smoke test installation in the CI for all the three PHP versions. (7.2, 7.3 and 7.4)

### Test

```bash
$ PHP_VERSION=7.2 make -f .ci/Makefile build install
$ PHP_VERSION=7.2 make -C packaging deb deb-install
```

```
{:timestamp=>"2020-07-22T15:02:10.336693+0000", :message=>"Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag", :level=>:warn}
{:timestamp=>"2020-07-22T15:02:10.613323+0000", :message=>"Created package", :path=>"build/packages/apm-agent-php_0.1-preview_all.deb"}
Creating sha512sum ...
...
+ dpkg -i build/packages/apm-agent-php_0.1-preview_all.deb
Selecting previously unselected package apm-agent-php.
(Reading database ... 12741 files and directories currently installed.)
Preparing to unpack .../apm-agent-php_0.1-preview_all.deb ...
Unpacking apm-agent-php (0.1-preview) ...
Setting up apm-agent-php (0.1-preview) ...
Installing Elastic PHP agent
  Extension configuration has just been added for the Elastic PHP agent.
; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
extension=/opt/elastic/apm-agent-php/extensions/elastic_apm.so
elastic_apm.bootstrap_php_part_file=/opt/elastic/apm-agent-php/src/bootstrap_php_part.php
; END OF AUTO-GENERATED
+ php -m
+ grep elastic
elastic_apm
+ composer install
...
Time: 5.27 seconds, Memory: 10.00 MB

OK (3 tests, 65 assertions)
```
