### PR TITLE
[CI] distribution binaries stored in the PHP version folder

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -115,6 +115,7 @@ pipeline {
             post {
               always {
                 dir("${BASE_DIR}"){
+                  junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/log_as_junit.xml")
                   archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/*")
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
               always {
                 dir("${BASE_DIR}"){
                   junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/log_as_junit.xml")
-                  archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/*")
+                  archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/${PHP_VERSION}/*")
                 }
               }
             }

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -17,7 +17,7 @@ prepare: ## Build docker image for the packaging
 
 create-%: prepare  ## Create the specific package
 	@echo 'Creating package ...'
-	@mkdir -p $(PWD)/$(OUTPUT)
+	@mkdir -p $(PWD)/$(OUTPUT)/$(PHP_VERSION)
 	@docker run --rm \
 		-v $(PWD):/app \
 		-w /app $(IMAGE) \
@@ -40,10 +40,10 @@ create-%: prepare  ## Create the specific package
 		src/ElasticApm=$(PHP_AGENT_DIR)/src \
 		src/bootstrap_php_part.php=$(PHP_AGENT_DIR)/src/bootstrap_php_part.php
 	@echo 'Creating sha512sum ...'
-	@BINARY=$$(ls -1 $(PWD)/$(OUTPUT)/*.$*) ;\
+	@BINARY=$$(ls -1 $(PWD)/$(OUTPUT)/$(PHP_VERSION)/*.$*) ;\
 	sha512sum $$BINARY > $$BINARY.sha512 ;\
-	sed -i.bck "s#$(PWD)/$(OUTPUT)/##g" $$BINARY.sha512 ;\
-	rm $(PWD)/$(OUTPUT)/*.bck
+	sed -i.bck "s#$(PWD)/$(OUTPUT)/$(PHP_VERSION)/##g" $$BINARY.sha512 ;\
+	rm $(PWD)/$(OUTPUT)/$(PHP_VERSION)/*.bck
 
 .PHONY: rpm
 rpm: create-rpm  ## Create the rpm installer
@@ -68,14 +68,14 @@ info: rpm-info deb-info  ## Show the package metadata for all the installers
 .PHONY: rpm-info
 rpm-info:  ## Show the rpm package metadata
 	@cd $(PWD) ;\
-	BINARY=$$(ls -1 $(OUTPUT)/*.rpm) ;\
+	BINARY=$$(ls -1 $(OUTPUT)/$(PHP_VERSION)/*.rpm) ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qip $$BINARY ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/rpm $(IMAGE) -qlp $$BINARY
 
 .PHONY: deb-info
 deb-info:  ## Show the deb package metadata
 	@cd $(PWD) ;\
-	BINARY=$$(ls -1 $(OUTPUT)/*.deb) ;\
+	BINARY=$$(ls -1 $(OUTPUT)/$(PHP_VERSION)/*.deb) ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) --info $$BINARY ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/dpkg $(IMAGE) -c $$BINARY
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -31,7 +31,7 @@ create-%: prepare  ## Create the specific package
 		--license 'ASL 2.0' \
 		--vendor 'Elasticsearch, Inc.' \
 		--description "PHP agent for Elastic APM\nGit Commit: ${GIT_SHA}" \
-		--package $(OUTPUT) \
+		--package $(OUTPUT)/$(PHP_VERSION) \
 		--chdir /app \
 		--after-install=packaging/post-install.sh \
 		packaging/post-install.sh=$(PHP_AGENT_DIR)/bin/post-install.sh \

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -2,7 +2,7 @@
 set -xe
 
 ## Install rpm package and configure the agent accordingly
-rpm -ivh build/packages/*.rpm
+rpm -ivh build/packages/**/*.rpm
 
 ## Verify if the elastic php agent is enabled
 if ! php -m | grep -q 'elastic' ; then

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -2,7 +2,7 @@
 set -x
 
 ## Install debian package and configure the agent accordingly
-dpkg -i build/packages/*.deb
+dpkg -i build/packages/**/*.deb
 
 ## Verify if the elastic php agent is enabled
 if ! php -m | grep -q 'elastic' ; then


### PR DESCRIPTION
### What

Since we currently support three different PHP minor versions in the CI, let's ensure the distributable that has been generated for each PHP version is stored in the PHP-version folder that was used to be compiled from.

In addition, to trend the JUnit report generated in the component tests

### Tests

See the artifacts in the build

![image](https://user-images.githubusercontent.com/2871786/88305038-eee68400-cd00-11ea-8ec1-9d42bb2ca3c6.png)
