### PR TITLE
[Packaging] restore php.ini if something bad happened

### DIFF
--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -38,7 +38,6 @@ function is_extension_installed() {
 ################################################################################
 #### Function add_extension_configuration_to_file ##############################
 function add_extension_configuration_to_file() {
-    cp -fa "$1" "${1}${BACKUP_EXTENSION}"
     tee -a "$1" <<EOF
 ; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
 extension=${EXTENSION_FILE_PATH}
@@ -57,6 +56,7 @@ if [ -e "${PHP_INI_FILE_PATH}" ] ; then
         echo '  extension configuration already exists for the Elastic PHP agent.'
         echo '  skipping ... '
     else
+        cp -fa "${PHP_INI_FILE_PATH}" "${PHP_INI_FILE_PATH}${BACKUP_EXTENSION}"
         add_extension_configuration_to_file "${PHP_INI_FILE_PATH}"
     fi
 else

--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -6,6 +6,7 @@
 PHP_AGENT_DIR=/opt/elastic/apm-agent-php
 EXTENSION_FILE_PATH="${PHP_AGENT_DIR}/extensions/elastic_apm.so"
 BOOTSTRAP_FILE_PATH="${PHP_AGENT_DIR}/src/bootstrap_php_part.php"
+BACKUP_EXTENSION=".agent.bck"
 
 ################################################################################
 ########################## FUNCTION CALLS BELOW ################################
@@ -37,7 +38,8 @@ function is_extension_installed() {
 ################################################################################
 #### Function add_extension_configuration_to_file ##############################
 function add_extension_configuration_to_file() {
-    tee -a "$@" <<EOF
+    cp -fa "$1" "${1}${BACKUP_EXTENSION}"
+    tee -a "$1" <<EOF
 ; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
 extension=${EXTENSION_FILE_PATH}
 elastic_apm.bootstrap_php_part_file=${BOOTSTRAP_FILE_PATH}
@@ -65,6 +67,10 @@ if is_extension_installed ; then
     echo 'Extension enabled successfully for Elastic PHP agent'
 else
     echo 'Failed enabling Elastic PHP agent extension'
+    if [ -e "${PHP_INI_FILE_PATH}${BACKUP_EXTENSION}" ] ; then
+        echo "Reverted changes in the file ${PHP_INI_FILE_PATH}"
+        mv -f "${PHP_INI_FILE_PATH}${BACKUP_EXTENSION}" "${PHP_INI_FILE_PATH}"
+    fi
     echo 'Set up the Agent manually as explained in:'
     echo 'https://github.com/elastic/apm-agent-php/blob/master/docs/setup.asciidoc'
 fi


### PR DESCRIPTION
## What
Let's restore the `php.ini` file if something bad happened. The restore should keep the file as used to be and also preserving the permissions.

## Tests

```bash
$ rm -rf build
$ PHP_VERSION=7.4 make -f .ci/Makefile build
$ PHP_VERSION=7.4 make -C packaging rpm
```

### Then, it will fail if installing php.7.4 in in php7.2:

```bash
$ PHP_VERSION=7.2 make -C packaging rpm-install
...

Installing Elastic PHP agent
; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
extension=/opt/elastic/apm-agent-php/extensions/elastic_apm.so
elastic_apm.bootstrap_php_part_file=/opt/elastic/apm-agent-php/src/bootstrap_php_part.php
; END OF AUTO-GENERATED
PHP Warning:  PHP Startup: Unable to load dynamic library '/opt/elastic/apm-agent-php/extensions/elastic_apm.so' (tried: /opt/elastic/apm-agent-php/extensions/elastic_apm.so (/opt/elastic/apm-agent-php/extensions/elastic_apm.so: undefined symbol: zend_hash_add), /usr/lib64/php/modules//opt/elastic/apm-agent-php/extensions/elastic_apm.so.so (/usr/lib64/php/modules//opt/elastic/apm-agent-php/extensions/elastic_apm.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
Failed enabling Elastic PHP agent extension
Reverted changes in the file /etc/php.ini
Set up the Agent manually as explained in:
https://github.com/elastic/apm-agent-php/blob/master/docs/setup.asciidoc
```

### Then it will work when installing it in a php.version 7.4

```bash
$ PHP_VERSION=7.4 make -C packaging rpm-install
Installing Elastic PHP agent
; THIS IS AN AUTO-GENERATED FILE by the Elastic PHP agent post-install.sh script
extension=/opt/elastic/apm-agent-php/extensions/elastic_apm.so
elastic_apm.bootstrap_php_part_file=/opt/elastic/apm-agent-php/src/bootstrap_php_part.php
; END OF AUTO-GENERATED
Extension enabled successfully for Elastic PHP agent
+ php -m
+ grep -q elastic
+ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
```

## Issues

Closes https://github.com/elastic/apm-agent-php/issues/112