### PR TITLE
[CI] Automate release to GitHub

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
@@ -24,204 +23,211 @@ pipeline {
     issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
-    stage('Checkout') {
-      options { skipDefaultCheckout() }
-      steps {
-        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-        deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        script {
-          dir("${BASE_DIR}"){
-            // Skip all the stages except docs for PR's with asciidoc and md changes only
-            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md|png)' ], shouldMatchAll: true)
+    stage('Initializing'){
+      options {
+        skipDefaultCheckout()
+        timeout(time: 1, unit: 'HOURS')
+      }
+      stages {
+        stage('Checkout') {
+          steps {
+            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              dir("${BASE_DIR}"){
+                // Skip all the stages except docs for PR's with asciidoc and md changes only
+                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md|png)' ], shouldMatchAll: true)
+              }
+            }
           }
         }
-      }
-    }
-    stage('BuildAndTest') {
-      when {
-        beforeAgent true
-        expression { return env.ONLY_DOCS == "false" }
-      }
-      failFast false
-      matrix {
-        agent { label 'linux && immutable' }
-        options { skipDefaultCheckout() }
-        axes {
-          axis {
-            name 'PHP_VERSION'
-            values '7.2', '7.3', '7.4'
+        stage('BuildAndTest') {
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
           }
-        }
-        stages {
-          stage('Build') {
-            steps {
-              withGithubNotify(context: "Build-${PHP_VERSION}") {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  // When running in the CI with multiple parallel stages
-                  // the access could be considered as a DDOS attack.
-                  retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-                    sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile prepare", label: 'prepare docker image'
+          failFast false
+          matrix {
+            agent { label 'linux && immutable' }
+            options { skipDefaultCheckout() }
+            axes {
+              axis {
+                name 'PHP_VERSION'
+                values '7.2', '7.3', '7.4'
+              }
+            }
+            stages {
+              stage('Build') {
+                steps {
+                  withGithubNotify(context: "Build-${PHP_VERSION}") {
+                    deleteDir()
+                    unstash 'source'
+                    dir("${BASE_DIR}"){
+                      // When running in the CI with multiple parallel stages
+                      // the access could be considered as a DDOS attack.
+                      retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+                        sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile prepare", label: 'prepare docker image'
+                      }
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile build", label: 'build'
+                    }
                   }
-                  sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile build", label: 'build'
+                }
+              }
+              stage('PHPT Tests') {
+                steps {
+                  withGithubNotify(context: "PHPT-Tests-${PHP_VERSION}", tab: 'tests') {
+                    dir("${BASE_DIR}"){
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile test", label: 'test'
+                    }
+                  }
+                }
+                post {
+                  always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
+                  }
+                }
+              }
+              stage('Generate for package') {
+                steps {
+                  withGithubNotify(context: "Generate-For-Package-${PHP_VERSION}") {
+                    dir("${BASE_DIR}"){
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile generate-for-package", label: 'generate-for-package'
+                      stash includes: 'src/ext/modules/*.so', name: "generate-for-package-${PHP_VERSION}"
+                    }
+                  }
+                }
+              }
+              stage('PHPUnit Tests') {
+                steps {
+                  withGithubNotify(context: "PHPUnit-Tests-${PHP_VERSION}", tab: 'tests') {
+                    dir("${BASE_DIR}"){
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile composer", label: 'composer'
+                    }
+                  }
                 }
               }
             }
           }
-          stage('PHPT Tests') {
-            steps {
-              withGithubNotify(context: "PHPT-Tests-${PHP_VERSION}", tab: 'tests') {
-                dir("${BASE_DIR}"){
-                  sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile test", label: 'test'
-                }
-              }
-            }
-            post {
-              always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
-              }
-            }
-          }
-          stage('Generate for package') {
-            steps {
-              withGithubNotify(context: "Generate-For-Package-${PHP_VERSION}") {
-                dir("${BASE_DIR}"){
-                  sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile generate-for-package", label: 'generate-for-package'
-                  stash includes: 'src/ext/modules/*.so', name: "generate-for-package-${PHP_VERSION}"
-                }
-              }
-            }
-          }
-          stage('PHPUnit Tests') {
-            steps {
-              withGithubNotify(context: "PHPUnit-Tests-${PHP_VERSION}", tab: 'tests') {
-                dir("${BASE_DIR}"){
-                  sh script: "PHP_VERSION=${PHP_VERSION} make -f .ci/Makefile composer", label: 'composer'
-                }
-              }
-            }
-          }
         }
-      }
-    }
-    stage('Package Generation') {
-      when {
-        beforeAgent true
-        expression { return env.ONLY_DOCS == "false" }
-      }
-      options { skipDefaultCheckout() }
-      steps {
-        withGithubNotify(context: "Package", tab: 'artifacts') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            unstash 'generate-for-package-7.2'
-            unstash 'generate-for-package-7.3'
-            unstash 'generate-for-package-7.4'
-            sh script: "make -C packaging package", label: 'package'
-            sh script: "make -C packaging info", label: 'package info'
-            stash includes: 'build/packages/*', name: 'package'
+        stage('Package Generation') {
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
           }
-        }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}"){
-            archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/*")
-          }
-        }
-      }
-    }
-    stage('Package-Test') {
-      when {
-        beforeAgent true
-        expression { return env.ONLY_DOCS == "false" }
-      }
-      failFast false
-      matrix {
-        agent { label 'linux && immutable' }
-        options { skipDefaultCheckout() }
-        axes {
-          axis {
-            name 'PHP_VERSION'
-            values '7.2', '7.3', '7.4'
-          }
-        }
-        stages {
-          stage('Package Test') {
-            steps {
-              withGithubNotify(context: "Package-Test-${PHP_VERSION}") {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  unstash 'package'
-                  sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging install", label: 'package install'
-                }
-              }
-            }
-            post {
-              always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
-              }
-            }
-          }
-        }
-      }
-    }
-    stage('Testing') {
-      when {
-        beforeAgent true
-        // TODO: && false in place to disable this particular section for the time being.
-        //       as agreed to avoid any misleading until this particular section has been implemented.
-        expression { return env.ONLY_DOCS == "false" && false }
-      }
-      matrix {
-        // TODO: This should be uncommented out when the implementation is in place
-        // agent { label 'linux && immutable' }
-        options { skipDefaultCheckout() }
-        axes {
-          axis {
-            name 'PHP_VERSION'
-            values '7.2', '7.3', '7.4'
-          }
-          axis {
-            name 'FRAMEWORK'
-            values 'nginx', 'apache', 'redis', 'memcached', 'mysql'
-          }
-        }
-        stages {
-          stage('Install') {
-            steps {
-              // TODO: This should be uncommented out when the implementation is in place
-              // deleteDir()
-              // unstash 'source'
+          options { skipDefaultCheckout() }
+          steps {
+            withGithubNotify(context: "Package", tab: 'artifacts') {
+              deleteDir()
+              unstash 'source'
               dir("${BASE_DIR}"){
-                echo 'TBD'
+                unstash 'generate-for-package-7.2'
+                unstash 'generate-for-package-7.3'
+                unstash 'generate-for-package-7.4'
+                sh script: "make -C packaging package", label: 'package'
+                sh script: "make -C packaging info", label: 'package info'
+                stash includes: 'build/packages/*', name: 'package'
               }
             }
           }
-          stage('Test') {
-            steps {
-              // TODO: This should be uncommented out when the implementation is in place
-              // deleteDir()
-              // unstash 'source'
+          post {
+            always {
               dir("${BASE_DIR}"){
-                sh 'scripts/test-framework.sh ${PHP_VERSION} ${FRAMEWORK}'
-              }
-            }
-            post {
-              always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
+                archiveArtifacts(allowEmptyArchive: true, artifacts: "build/packages/*")
               }
             }
           }
         }
-        post {
-          always {
-            echo 'STORE docker logs'
+        stage('Package-Test') {
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
+          }
+          failFast false
+          matrix {
+            agent { label 'linux && immutable' }
+            options { skipDefaultCheckout() }
+            axes {
+              axis {
+                name 'PHP_VERSION'
+                values '7.2', '7.3', '7.4'
+              }
+            }
+            stages {
+              stage('Package Test') {
+                steps {
+                  withGithubNotify(context: "Package-Test-${PHP_VERSION}") {
+                    deleteDir()
+                    unstash 'source'
+                    dir("${BASE_DIR}"){
+                      unstash 'package'
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging install", label: 'package install'
+                    }
+                  }
+                }
+                post {
+                  always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                  }
+                }
+              }
+            }
+          }
+        }
+        stage('Testing') {
+          when {
+            beforeAgent true
+            // TODO: && false in place to disable this particular section for the time being.
+            //       as agreed to avoid any misleading until this particular section has been implemented.
+            expression { return env.ONLY_DOCS == "false" && false }
+          }
+          matrix {
+            // TODO: This should be uncommented out when the implementation is in place
+            // agent { label 'linux && immutable' }
+            options { skipDefaultCheckout() }
+            axes {
+              axis {
+                name 'PHP_VERSION'
+                values '7.2', '7.3', '7.4'
+              }
+              axis {
+                name 'FRAMEWORK'
+                values 'nginx', 'apache', 'redis', 'memcached', 'mysql'
+              }
+            }
+            stages {
+              stage('Install') {
+                steps {
+                  // TODO: This should be uncommented out when the implementation is in place
+                  // deleteDir()
+                  // unstash 'source'
+                  dir("${BASE_DIR}"){
+                    echo 'TBD'
+                  }
+                }
+              }
+              stage('Test') {
+                steps {
+                  // TODO: This should be uncommented out when the implementation is in place
+                  // deleteDir()
+                  // unstash 'source'
+                  dir("${BASE_DIR}"){
+                    sh 'scripts/test-framework.sh ${PHP_VERSION} ${FRAMEWORK}'
+                  }
+                }
+                post {
+                  always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
+                  }
+                }
+              }
+            }
+            post {
+              always {
+                echo 'STORE docker logs'
+              }
+            }
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -226,6 +226,59 @@ pipeline {
         }
       }
     }
+    stage('Release') {
+      options {
+        skipDefaultCheckout()
+        timeout(time: 12, unit: 'HOURS')
+      }
+      when {
+        beforeAgent true
+        tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+      }
+      stages {
+        stage('Notify') {
+          options { skipDefaultCheckout() }
+          steps {
+            emailext subject: "[${env.REPO}] Release ready to be pushed", to: "${NOTIFY_TO}",
+                              body: "Please go to ${env.BUILD_URL}input to approve or reject within 12 hours.\n Changes: ${env.TAG_NAME}"
+            script {
+              def should_continue = input(message: "You are about to release version ${env.TAG_NAME}",
+                                          parameters: [ [$class: 'ChoiceParameterDefinition',
+                                                          name: 'Do you wish to release it?',
+                                                          choices: ['Yes', 'No']] ])
+              env.RELEASE = should_continue.equals('Yes')
+            }
+          }
+        }
+        stage('Release CI') {
+          when {
+            beforeAgent true
+            expression { return env.RELEASE == 'true' }
+          }
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}") {
+              unstash 'package'
+              withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GITHUB_TOKEN')]) {
+                sh script: 'make -f .ci/Makefile release', label: 'release'
+              }
+            }
+          }
+          post {
+            success {
+              emailext subject: "[${env.REPO}] Release published", to: "${env.NOTIFY_TO}", body: "Great news, the release has been done successfully."
+            }
+            always {
+              script {
+                currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"
+              }
+            }
+          }
+        }
+      }
+    }
   }
   post {
     cleanup {

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -53,3 +53,21 @@ composer: prepare  ## Run composer
 			&& cd /app \
 			&& composer install \
 			&& composer static_check_and_run_component_tests_standalone_envs'
+
+.PHONY: release
+release:  ## Run a release given the GITHUB_TOKEN and TAG_NAME
+ifndef GITHUB_TOKEN
+	@echo "Please set GITHUB_TOKEN in the environment to perform a release"
+	exit 1
+endif
+ifndef TAG_NAME
+	@echo "Please set TAG_NAME in the environment to perform a release"
+	exit 1
+endif
+	@docker run --rm -t \
+		--env GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		--env TAG_NAME=$(TAG_NAME) \
+		--volume "$(PWD)":/app \
+		--workdir /app \
+		golang:1.14.7 \
+		/app/.ci/release.sh

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+USER=elastic
+REPO=apm-agent-php
+
+## Install tooling
+go get github.com/github-release/github-release
+
+## Create a formal release
+github-release release \
+    --user ${USER} \
+    --repo ${REPO} \
+    --tag "${TAG_NAME}"
+
+## Upload the distribution files
+for package in build/packages/* ; do
+  name=$(basename "${package}")
+  github-release upload \
+      --user ${USER} \
+      --repo ${REPO} \
+      --tag "${TAG_NAME}" \
+      --name "${name}" \
+      --file "${package}" 
+done

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,6 +22,9 @@ PHP_VERSION=7.2 make -f .ci/Makefile generate-for-package
 ## To install with composer
 PHP_VERSION=7.2 make -f .ci/Makefile composer
 
+## To release given the GITHUB_TOKEN and TAG_NAME
+GITHUB_TOKEN=**** TAG_NAME=v1.0.0 make -f .ci/Makefile release
+
 ## Help goal will provide further details
 make -f .ci/Makefile help
 ```


### PR DESCRIPTION
## What

- Automate the release process to be tag-based, with the format `v[0-9]*`
- Makefile changed to drive the release automation.
  - Will create a release based on the given tag.
  - Will upload all the artifacts.
- Timeout for the build/test of one hour and timeout for the release of 12 hours. See https://github.com/elastic/apm-agent-php/commit/3af59242393deac253b6aff343d0e6fab9ce8c6c, it does ntohing but adding a new parent stage for all the build/test stages.
- Notify when the tag is ready to be released with an email.
- Gatekeeper based, so it requires an input approval to be able to do the release.
- Using https://github.com/github-release/github-release to access the GH release/upload asserts.

## Tests

required to run the build and generate package goals.

```bash
## change USER=elastic for USER=v1v in .ci/release.sh
## export your GITHUB token
export GITHUB_TOKEN=****
## Create a release for the tag 1.4
TAG_NAME=1.4 make -f .ci/Makefile release
```

```
+ USER=v1v
+ REPO=apm-agent-php
+ go get github.com/github-release/github-release
+ github-release release --user v1v --repo apm-agent-php --tag 1.4
+ for package in build/packages/*
++ basename build/packages/apm-agent-php-0.1_preview-1.noarch.rpm
+ name=apm-agent-php-0.1_preview-1.noarch.rpm
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php-0.1_preview-1.noarch.rpm --file build/packages/apm-agent-php-0.1_preview-1.noarch.rpm
+ for package in build/packages/*
++ basename build/packages/apm-agent-php-0.1_preview-1.noarch.rpm.sha512
+ name=apm-agent-php-0.1_preview-1.noarch.rpm.sha512
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php-0.1_preview-1.noarch.rpm.sha512 --file build/packages/apm-agent-php-0.1_preview-1.noarch.rpm.sha512
+ for package in build/packages/*
++ basename build/packages/apm-agent-php.tar
+ name=apm-agent-php.tar
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php.tar --file build/packages/apm-agent-php.tar
+ for package in build/packages/*
++ basename build/packages/apm-agent-php.tar.sha512
+ name=apm-agent-php.tar.sha512
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php.tar.sha512 --file build/packages/apm-agent-php.tar.sha512
+ for package in build/packages/*
++ basename build/packages/apm-agent-php_0.1-preview_all.deb
+ name=apm-agent-php_0.1-preview_all.deb
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php_0.1-preview_all.deb --file build/packages/apm-agent-php_0.1-preview_all.deb
+ for package in build/packages/*
++ basename build/packages/apm-agent-php_0.1-preview_all.deb.sha512
+ name=apm-agent-php_0.1-preview_all.deb.sha512
+ github-release upload --user v1v --repo apm-agent-php --tag 1.4 --name apm-agent-php_0.1-preview_all.deb.sha512 --file build/packages/apm-agent-php_0.1-preview_all.deb.sha512
```

See https://github.com/v1v/apm-agent-php/releases/tag/1.4

## Use case

When a tag was created with the format `v[0-9]*` from a particular commit from the master branch, 
Then the CI pipeline will be in charge to release it.

## Issues

Related https://github.com/elastic/apm-agent-php/issues/10