### PR TITLE
[packaging] include C source file from .so is built

### DIFF
--- a/packaging/create-package.sh
+++ b/packaging/create-package.sh
@@ -18,6 +18,16 @@ fi
 BUILD_SRC_EXT_DIR=build/src
 mkdir -p ${BUILD_SRC_EXT_DIR}
 cp -rf src/ext ${BUILD_SRC_EXT_DIR}
+if [ -e ${BUILD_SRC_EXT_DIR}/ext/.gitignore ] ; then
+	while IFS= read -r line
+	do
+		if [ -n "$line" ]; then
+			if case $line in "#"*) false;; *) true;; esac; then
+				rm -rf "${BUILD_SRC_EXT_DIR}/ext/${line}" || true
+			fi
+		fi
+	done < "${BUILD_SRC_EXT_DIR}/ext/.gitignore"
+fi
 
 ## Create package
 fpm --input-type dir \
@@ -34,7 +44,7 @@ fpm --input-type dir \
 		--chdir /app ${FPM_FLAGS} \
 		--after-install=packaging/post-install.sh \
 		packaging/post-install.sh=${PHP_AGENT_DIR}/bin/post-install.sh \
-		${BUILD_SRC_EXT_DIR}=${PHP_AGENT_DIR}/src \
+		${BUILD_SRC_EXT_DIR}=${PHP_AGENT_DIR} \
 		${BUILD_EXT_DIR}=${PHP_AGENT_DIR}/extensions \
 		README.md=${PHP_AGENT_DIR}/docs/README.md \
 		src/ElasticApm=${PHP_AGENT_DIR}/src \

--- a/packaging/create-package.sh
+++ b/packaging/create-package.sh
@@ -14,6 +14,11 @@ elif [ "${TYPE}" = 'deb' ] || [ "${TYPE}" = 'rpm' ] ; then
 	find ${BUILD_EXT_DIR} -type f -name '*-alpine.so' -delete
 fi
 
+## src/ext files to be archived in the package
+BUILD_SRC_EXT_DIR=build/src
+mkdir -p ${BUILD_SRC_EXT_DIR}
+cp -rf src/ext ${BUILD_SRC_EXT_DIR}
+
 ## Create package
 fpm --input-type dir \
 		--output-type "${TYPE}" \
@@ -29,6 +34,7 @@ fpm --input-type dir \
 		--chdir /app ${FPM_FLAGS} \
 		--after-install=packaging/post-install.sh \
 		packaging/post-install.sh=${PHP_AGENT_DIR}/bin/post-install.sh \
+		${BUILD_SRC_EXT_DIR}=${PHP_AGENT_DIR}/src \
 		${BUILD_EXT_DIR}=${PHP_AGENT_DIR}/extensions \
 		README.md=${PHP_AGENT_DIR}/docs/README.md \
 		src/ElasticApm=${PHP_AGENT_DIR}/src \

--- a/packaging/create-package.sh
+++ b/packaging/create-package.sh
@@ -16,17 +16,20 @@ fi
 
 ## src/ext files to be archived in the package
 BUILD_SRC_EXT_DIR=build/src
+IGNORE_FILE=${BUILD_SRC_EXT_DIR}/ext/.gitignore
 mkdir -p ${BUILD_SRC_EXT_DIR}
 cp -rf src/ext ${BUILD_SRC_EXT_DIR}
-if [ -e ${BUILD_SRC_EXT_DIR}/ext/.gitignore ] ; then
+if [ -e ${IGNORE_FILE} ] ; then
 	while IFS= read -r line
 	do
 		if [ -n "$line" ]; then
 			if case $line in "#"*) false;; *) true;; esac; then
-				rm -rf "${BUILD_SRC_EXT_DIR}/ext/${line}" || true
+				# shellcheck disable=SC2086
+				rm -rf ${BUILD_SRC_EXT_DIR}/ext/${line} || true
 			fi
 		fi
-	done < "${BUILD_SRC_EXT_DIR}/ext/.gitignore"
+	done < "${IGNORE_FILE}"
+	rm ${IGNORE_FILE} || true
 fi
 
 ## Create package


### PR DESCRIPTION
### What

- Add `src/ext` folder in the `/opt/elastic/apm-agent-php/src/ext` location of the rpm/deb/apk/tar.gz packages.
- Filter the generated files that defined in the `src/ext/.gitignore`

### Test

```
# Prepare so
make -f .ci/Makefile build generate-for-package

# Generate package and run installation for debian
make -C packaging clean deb deb-install

# Validate src files have been included
make -C packaging  deb-info | grep './opt/elastic/apm-agent-php/src/ext/' | wc -l
git clean -fdx
find src/ext ! -name '.gitignore' | wc -l
```