### PR TITLE
Fix HAS_BACKTRACE detection

### DIFF
--- a/src/ext/platform.h
+++ b/src/ext/platform.h
@@ -11,8 +11,11 @@
 
 #pragma once
 
-#ifdef __GLIBC__
-#   define ELASTIC_APM_PLATFORM_HAS_BACKTRACE
+#ifndef PHP_WIN32
+#   include <features.h>
+#   ifdef __GLIBC__
+#       define ELASTIC_APM_PLATFORM_HAS_BACKTRACE
+#   endif
 #endif
 
 #include <stdbool.h>


### PR DESCRIPTION
`ELASTIC_APM_PLATFORM_HAS_BACKTRACE` was always undefined because before checking `#ifdef __GLIBC__`  `<features.h>` needs to be included