### PR TITLE
[TEMP] Add `URL` label to `curl_exec` spans

### DIFF
--- a/src/ElasticApm/Impl/AutoInstrument/CurlAutoInstrumentation.php
+++ b/src/ElasticApm/Impl/AutoInstrument/CurlAutoInstrumentation.php
@@ -59,9 +59,15 @@ final class CurlAutoInstrumentation
                         if (!$hasExitedByException) {
                             if (!is_null($this->curlHandle)) {
                                 $info = curl_getinfo($this->curlHandle);
-                                $httpCode = ArrayUtil::getValueIfKeyExistsElse('http_code', $info, null);
-                                if (!is_null($httpCode)) {
+
+                                if (
+                                    !is_null($httpCode = ArrayUtil::getValueIfKeyExistsElse('http_code', $info, null))
+                                ) {
                                     $this->span->setLabel('HTTP status', $httpCode);
+                                }
+
+                                if (!is_null($url = ArrayUtil::getValueIfKeyExistsElse('url', $info, null))) {
+                                    $this->span->setLabel('URL', $url);
                                 }
                             }
                         }


### PR DESCRIPTION
Temporarily add `URL` label to `curl_exec` spans to help investigate the question at https://discuss.elastic.co/t/automatic-transaction-time-not-aligned-with-real-execution-time/245975.

**Note:** This is just a temporary change - the correct solution should be implementing #151.