### PR TITLE
docs: prepare for doc build

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,4 +19,6 @@
 [[release-notes-alpha-1]]
 ==== Alpha1 release
 
+_Coming soon_
+
 // Using the template above, release notes go here.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,11 +1,10 @@
 include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-// **Fix: uncomment when docs are added to the Elastic documentation build**
-// ifdef::env-github[]
-// NOTE: For the best reading experience,
-// please view this documentation at https://www.elastic.co/guide/en/apm/agent/php[elastic.co]
-// endif::[]
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/php[elastic.co]
+endif::[]
 
 = APM PHP Agent Reference
 

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,0 +1,2 @@
+You are looking at preliminary documentation for a future release.
+This project is still in development; do not use it in a production environment.

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -3,6 +3,6 @@
 [[release-notes]]
 == Release notes
 
-* <<release-notes-alpha>>
+* <<release-notes-alpha>> (Coming soon)
 
 include::../CHANGELOG.asciidoc[]


### PR DESCRIPTION
This PR prepares the APM PHP documentation for Elastic's documentation build. Notably, it adds a header to each page of the docs with the following disclaimer:

<img width="771" alt="Screen Shot 2020-08-24 at 12 06 34 PM" src="https://user-images.githubusercontent.com/5618806/91086124-509d5500-e603-11ea-9145-bc5432619e04.png">

For https://github.com/elastic/docs/pull/1948.