### PR TITLE
Fix flaky component tests

### DIFF
--- a/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerTestEnv.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerTestEnv.php
@@ -31,7 +31,7 @@ final class BuiltinHttpServerTestEnv extends HttpServerTestEnvBase
         )->addContext('this', $this);
     }
 
-    protected function ensureAppCodeHostServerStarted(TestProperties $testProperties): void
+    protected function ensureAppCodeHostServerRunning(TestProperties $testProperties): void
     {
         if (isset($this->appCodeHostServerPort)) {
             return;
@@ -50,7 +50,7 @@ final class BuiltinHttpServerTestEnv extends HttpServerTestEnvBase
             . ' "' . __DIR__ . DIRECTORY_SEPARATOR . self::APP_CODE_HOST_ROUTER_SCRIPT . '"',
             $this->buildEnvVars($testProperties->configSetter->additionalEnvVars())
         );
-        $this->checkHttpServerStatus(
+        $this->ensureHttpServerRunning(
             $appCodeHostServerPort,
             /* dbgServerDesc */ DbgUtil::fqToShortClassName(BuiltinHttpServerAppCodeHost::class)
         );

--- a/tests/ElasticApmTests/ComponentTests/Util/CliScriptTestEnv.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/CliScriptTestEnv.php
@@ -32,7 +32,7 @@ final class CliScriptTestEnv extends TestEnvBase
 
     protected function sendRequestToInstrumentedApp(TestProperties $testProperties): void
     {
-        $this->ensureMockApmServerStarted();
+        $this->ensureMockApmServerRunning();
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
@@ -34,8 +34,8 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
 
     protected function sendRequestToInstrumentedApp(TestProperties $testProperties): void
     {
-        $this->ensureMockApmServerStarted();
-        $this->ensureAppCodeHostServerStarted($testProperties);
+        $this->ensureMockApmServerRunning();
+        $this->ensureAppCodeHostServerRunning($testProperties);
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(
@@ -69,7 +69,7 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
         );
     }
 
-    abstract protected function ensureAppCodeHostServerStarted(TestProperties $testProperties): void;
+    abstract protected function ensureAppCodeHostServerRunning(TestProperties $testProperties): void;
 
     protected function verifyRootTransactionName(
         TestProperties $testProperties,


### PR DESCRIPTION
When starting an external process that functions as an HTTP Server check if it's indeed responding to request on the corresponding port. If it doesn't fail the tests immediately.