### PR TITLE
[CI] run whole build for branches/tags when only DOCS

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     BASE_DIR = "src/go.elastic.co/apm/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    ONLY_DOCS = "false"
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              dir("${BASE_DIR}"){
-                // Skip all the stages except docs for PR's with asciidoc and md changes only
-                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md|png)' ], shouldMatchAll: true)
+            dir("${BASE_DIR}"){
+              // Skip all the stages except docs for PR's with asciidoc and md changes only
+              whenTrue(isPR()) {
+                setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md|png)' ], shouldMatchAll: true))
               }
             }
           }


### PR DESCRIPTION
### What

Enable builds for branches/tags that were built when a PR with only DOCS was merged.

### Why

PRs should be faster executed when only DOCS, but for branches/tags we agree to run everything always, this will help to ensure the artifacts link is predictable and artifacts are always generated.

OTOH, this will help to detect any kind of flakiness, if any.