### PR TITLE
Add retry for starting HTTP servers used for testing

### DIFF
--- a/src/ElasticApm/Impl/Config/EnvVarsRawSnapshotSource.php
+++ b/src/ElasticApm/Impl/Config/EnvVarsRawSnapshotSource.php
@@ -11,7 +11,7 @@ namespace Elastic\Apm\Impl\Config;
  */
 final class EnvVarsRawSnapshotSource implements RawSnapshotSourceInterface
 {
-    public const DEFAULT_PREFIX = 'ELASTIC_APM_';
+    public const DEFAULT_NAME_PREFIX = 'ELASTIC_APM_';
 
     /** @var array<string, string> */
     private $optionToEnvVarName;

--- a/src/ElasticApm/Impl/Config/IntOptionMetadata.php
+++ b/src/ElasticApm/Impl/Config/IntOptionMetadata.php
@@ -15,10 +15,21 @@ use Elastic\Apm\Impl\Util\ArrayUtil;
  */
 final class IntOptionMetadata extends OptionMetadataBase
 {
-    /** @inheritDoc */
     public function __construct(int $defaultValue)
     {
         parent::__construct($defaultValue);
+    }
+
+    public static function parseValue(string $rawValue): int
+    {
+        if (is_numeric($rawValue)) {
+            $valueAsInt = intval($rawValue);
+            if (strval($valueAsInt) === $rawValue) {
+                return $valueAsInt;
+            }
+        }
+
+        throw new ParseException("Not a valid int value. Raw option value: `$rawValue'");
     }
 
     /**
@@ -30,13 +41,6 @@ final class IntOptionMetadata extends OptionMetadataBase
      */
     public function parse(string $rawValue)
     {
-        if (is_numeric($rawValue)) {
-            $valueAsInt = intval($rawValue);
-            if (strval($valueAsInt) === $rawValue) {
-                return $valueAsInt;
-            }
-        }
-
-        throw new ParseException("Not a valid int value. Raw option value: `$rawValue'");
+        return self::parseValue($rawValue);
     }
 }

--- a/src/ElasticApm/Impl/Config/NullableIntOptionMetadata.php
+++ b/src/ElasticApm/Impl/Config/NullableIntOptionMetadata.php
@@ -9,11 +9,11 @@ namespace Elastic\Apm\Impl\Config;
  *
  * @internal
  *
- * @extends OptionMetadataBase<?string>
+ * @extends OptionMetadataBase<?int>
  */
-final class NullableStringOptionMetadata extends OptionMetadataBase
+final class NullableIntOptionMetadata extends OptionMetadataBase
 {
-    public function __construct(?string $defaultValue = null)
+    public function __construct(?int $defaultValue = null)
     {
         parent::__construct($defaultValue);
     }
@@ -23,10 +23,10 @@ final class NullableStringOptionMetadata extends OptionMetadataBase
      *
      * @return mixed
      *
-     * @phpstan-return string
+     * @phpstan-return int
      */
     public function parse(string $rawValue)
     {
-        return $rawValue;
+        return IntOptionMetadata::parseValue($rawValue);
     }
 }

--- a/src/ElasticApm/Impl/Config/OptionMetadataBase.php
+++ b/src/ElasticApm/Impl/Config/OptionMetadataBase.php
@@ -9,7 +9,7 @@ namespace Elastic\Apm\Impl\Config;
  *
  * @internal
  *
- * @template T
+ * @template   T
  *
  * @implements OptionMetadataInterface<T>
  */
@@ -20,6 +20,8 @@ abstract class OptionMetadataBase implements OptionMetadataInterface
 
     /**
      * @param mixed $defaultValue
+     *
+     * @phpstan-param T $defaultValue
      */
     public function __construct($defaultValue)
     {

--- a/src/ElasticApm/Impl/Config/OptionMetadataBase.php
+++ b/src/ElasticApm/Impl/Config/OptionMetadataBase.php
@@ -15,7 +15,10 @@ namespace Elastic\Apm\Impl\Config;
  */
 abstract class OptionMetadataBase implements OptionMetadataInterface
 {
-    /** @var mixed */
+    /**
+     * @var mixed
+     * @phpstan-var T
+     */
     private $defaultValue;
 
     /**

--- a/src/ElasticApm/Impl/Config/SnapshotTrait.php
+++ b/src/ElasticApm/Impl/Config/SnapshotTrait.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Elastic\Apm\Impl\Config;
 
+use Elastic\Apm\Impl\Util\ArrayUtil;
+use Elastic\Apm\Impl\Util\DbgUtil;
+use Elastic\Apm\Impl\Util\ObjectToStringBuilder;
 use Elastic\Apm\Impl\Util\TextUtil;
 use RuntimeException;
 
@@ -14,6 +17,9 @@ use RuntimeException;
  */
 trait SnapshotTrait
 {
+    /** @var array<string, mixed> */
+    private $optNameToParsedValue;
+
     /**
      * @param array<string, mixed> $optNameToParsedValue
      */
@@ -27,5 +33,24 @@ trait SnapshotTrait
             }
             $this->$propertyName = $parsedValue;
         }
+
+        $this->optNameToParsedValue = $optNameToParsedValue;
+    }
+
+    /**
+     * @param string $optName
+     *
+     * @return mixed
+     */
+    public function getOptionValueByName(string $optName)
+    {
+        return ArrayUtil::getValueIfKeyExistsElse($optName, $this->optNameToParsedValue, null);
+    }
+
+    public function __toString(): string
+    {
+        $builder = new ObjectToStringBuilder(DbgUtil::fqToShortClassName(get_called_class()));
+        $builder->add('optNameToParsedValue', $this->optNameToParsedValue);
+        return $builder->build();
     }
 }

--- a/src/ElasticApm/Impl/Log/EnabledLoggerProxy.php
+++ b/src/ElasticApm/Impl/Log/EnabledLoggerProxy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Elastic\Apm\Impl\Log;
 
+use Throwable;
+
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
  *
@@ -41,6 +43,28 @@ final class EnabledLoggerProxy
             $this->statementLevel,
             $message,
             $statementCtx,
+            $this->srcCodeLine,
+            $this->srcCodeFunc,
+            $this->loggerData,
+            /* numberOfStackFramesToSkip */ 1
+        );
+        // return dummy bool to suppress PHPStan's "Right side of && is always false"
+        return true;
+    }
+
+    /**
+     * @param Throwable            $throwable
+     * @param string               $message
+     * @param array<string, mixed> $statementCtx
+     *
+     * @return bool
+     */
+    public function logThrowable(Throwable $throwable, string $message, array $statementCtx = []): bool
+    {
+        $this->loggerData->backend->log(
+            $this->statementLevel,
+            $message,
+            $statementCtx + ['throwable' => $throwable],
             $this->srcCodeLine,
             $this->srcCodeFunc,
             $this->loggerData,

--- a/src/ElasticApm/Impl/Tracer.php
+++ b/src/ElasticApm/Impl/Tracer.php
@@ -92,7 +92,7 @@ final class Tracer implements TracerInterface
               ?? new CompositeRawSnapshotSource(
                   [
                       new IniRawSnapshotSource(IniRawSnapshotSource::DEFAULT_PREFIX, $optionNames),
-                      new EnvVarsRawSnapshotSource(EnvVarsRawSnapshotSource::DEFAULT_PREFIX, $optionNames),
+                      new EnvVarsRawSnapshotSource(EnvVarsRawSnapshotSource::DEFAULT_NAME_PREFIX, $optionNames),
                   ]
               );
 

--- a/tests/ElasticApmTests/ComponentTests/Util/AllComponentTestsOptionsMetadata.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AllComponentTestsOptionsMetadata.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Elastic\Apm\Tests\ComponentTests\Util;
 
-use Elastic\Apm\Impl\Config\IntOptionMetadata;
 use Elastic\Apm\Impl\Config\LogLevelOptionMetadata;
+use Elastic\Apm\Impl\Config\NullableIntOptionMetadata;
 use Elastic\Apm\Impl\Config\NullableStringOptionMetadata;
 use Elastic\Apm\Impl\Config\OptionMetadataInterface;
-use Elastic\Apm\Impl\Config\StringOptionMetadata;
 use Elastic\Apm\Impl\Log\Level;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 
@@ -21,9 +20,13 @@ final class AllComponentTestsOptionsMetadata
 {
     use StaticClassTrait;
 
-    public const SPAWNED_PROCESSES_CLEANER_PORT_OPTION_NAME = 'spawned_processes_cleaner_port';
-    public const TEST_ENV_ID_OPTION_NAME = 'test_env_id';
-    public const INT_OPTION_NOT_SET = -1;
+    public const APP_CODE_CLASS_OPTION_NAME = 'app_code_class';
+    public const APP_CODE_METHOD_OPTION_NAME = 'app_code_method';
+    public const RESOURCES_CLEANER_PORT_OPTION_NAME = 'resources_cleaner_port';
+    public const RESOURCES_CLEANER_SERVER_ID_OPTION_NAME = 'resources_cleaner_server_id';
+    public const ROOT_PROCESS_ID_OPTION_NAME = 'root_process_id';
+    public const THIS_SERVER_ID_OPTION_NAME = 'this_server_id';
+    public const THIS_SERVER_PORT_OPTION_NAME = 'this_server_port';
 
     /**
      * @return array<string, OptionMetadataInterface<mixed>> Option name to metadata
@@ -31,13 +34,17 @@ final class AllComponentTestsOptionsMetadata
     public static function build(): array
     {
         return [
-            AppCodeHostKindOptionMetadata::NAME              => new AppCodeHostKindOptionMetadata(),
-            'app_code_php_exe'                               => new NullableStringOptionMetadata(),
-            'app_code_php_ini'                               => new NullableStringOptionMetadata(),
-            'log_level'                                      => new LogLevelOptionMetadata(Level::TRACE),
-            'mock_apm_server_port'                           => new IntOptionMetadata(self::INT_OPTION_NOT_SET),
-            self::SPAWNED_PROCESSES_CLEANER_PORT_OPTION_NAME => new IntOptionMetadata(self::INT_OPTION_NOT_SET),
-            self::TEST_ENV_ID_OPTION_NAME                    => new StringOptionMetadata(''),
+            self::APP_CODE_CLASS_OPTION_NAME              => new NullableStringOptionMetadata(),
+            AppCodeHostKindOptionMetadata::NAME           => new AppCodeHostKindOptionMetadata(),
+            self::APP_CODE_METHOD_OPTION_NAME             => new NullableStringOptionMetadata(),
+            'app_code_php_exe'                            => new NullableStringOptionMetadata(),
+            'app_code_php_ini'                            => new NullableStringOptionMetadata(),
+            'log_level'                                   => new LogLevelOptionMetadata(Level::TRACE),
+            self::RESOURCES_CLEANER_PORT_OPTION_NAME      => new NullableIntOptionMetadata(),
+            self::RESOURCES_CLEANER_SERVER_ID_OPTION_NAME => new NullableStringOptionMetadata(),
+            self::ROOT_PROCESS_ID_OPTION_NAME             => new NullableIntOptionMetadata(),
+            self::THIS_SERVER_ID_OPTION_NAME              => new NullableStringOptionMetadata(),
+            self::THIS_SERVER_PORT_OPTION_NAME            => new NullableIntOptionMetadata(),
         ];
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
@@ -43,13 +43,13 @@ abstract class AppCodeHostBase extends CliProcessBase
         && $loggerProxy->log('Done', ['Environment variables' => getenv()]);
     }
 
-    protected function registerWithSpawnedProcessesCleaner(): void
+    protected function registerWithResourcesCleaner(): void
     {
         // We don't want any of the infrastructure operations to be recorded as application's APM events
         ElasticApm::pauseRecording();
 
         try {
-            parent::registerWithSpawnedProcessesCleaner();
+            parent::registerWithResourcesCleaner();
         } finally {
             ElasticApm::resumeRecording();
         }

--- a/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerAppCodeHost.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerAppCodeHost.php
@@ -48,14 +48,16 @@ final class BuiltinHttpServerAppCodeHost extends AppCodeHostBase
         return $_SERVER['REQUEST_URI'] === TestEnvBase::STATUS_CHECK_URI;
     }
 
-    protected function shouldRegisterWithSpawnedProcessesCleaner(): bool
+    protected function shouldRegisterThisProcessWithResourcesCleaner(): bool
     {
-        // We should register with SpawnedProcessesCleaner only on the status-check request
+        // We should register with ResourcesCleaner only on the status-check request
         return self::isStatusCheck();
     }
 
-    protected function parseArgs(): void
+    protected function processConfig(): void
     {
+        parent::processConfig();
+
         if (!self::isStatusCheck()) {
             $this->appCodeClass = self::getRequestHeader(self::CLASS_HEADER_NAME);
             $this->appCodeMethod = self::getRequestHeader(self::METHOD_HEADER_NAME);
@@ -64,7 +66,7 @@ final class BuiltinHttpServerAppCodeHost extends AppCodeHostBase
 
     protected function runImpl(): void
     {
-        $response = self::verifyTestEnvIdEx([__CLASS__, 'getRequestHeader']);
+        $response = self::verifyServerIdEx([__CLASS__, 'getRequestHeader']);
         if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
             self::sendResponse($response);
             return;

--- a/tests/ElasticApmTests/ComponentTests/Util/CliScriptAppCodeHost.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/CliScriptAppCodeHost.php
@@ -9,9 +9,6 @@ use Elastic\Apm\Tests\Util\TestLogCategory;
 
 final class CliScriptAppCodeHost extends AppCodeHostBase
 {
-    public const CLASS_CMD_OPT_NAME = 'class';
-    public const METHOD_CMD_OPT_NAME = 'method';
-
     /** @var Logger */
     private $logger;
 
@@ -27,30 +24,18 @@ final class CliScriptAppCodeHost extends AppCodeHostBase
         )->addContext('this', $this);
     }
 
-    protected function parseArgs(): void
+    protected function processConfig(): void
     {
-        $longOpts = [];
+        parent::processConfig();
 
-        // --class=MyClass - required value
-        $longOpts[] = self::CLASS_CMD_OPT_NAME . ':';
-
-        // --method=myMethod - required value
-        $longOpts[] = self::METHOD_CMD_OPT_NAME . ':';
-
-        $parsedCliOptions = getopt(/* shortOpts */ '', $longOpts);
-
-        $this->appCodeClass = $this->checkRequiredCliOption(self::CLASS_CMD_OPT_NAME, $parsedCliOptions);
-        $this->appCodeMethod = $this->checkRequiredCliOption(self::METHOD_CMD_OPT_NAME, $parsedCliOptions);
+        $this->appCodeClass = self::getRequiredTestOption(AllComponentTestsOptionsMetadata::APP_CODE_CLASS_OPTION_NAME);
+        $this->appCodeMethod = self::getRequiredTestOption(
+            AllComponentTestsOptionsMetadata::APP_CODE_METHOD_OPTION_NAME
+        );
     }
 
     protected function runImpl(): void
     {
         $this->callAppCode();
-    }
-
-    protected function cliHelpOptions(): string
-    {
-        return ' --' . self::CLASS_CMD_OPT_NAME . /** @lang text */ '=<class name>'
-               . ' --' . self::METHOD_CMD_OPT_NAME . /** @lang text */ '=<method name>';
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/CliScriptTestEnv.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/CliScriptTestEnv.php
@@ -41,10 +41,18 @@ final class CliScriptTestEnv extends TestEnvBase
         );
         TestProcessUtil::runProcessAndWaitUntilExit(
             $testProperties->configSetter->appCodePhpCmd()
-            . ' "' . __DIR__ . DIRECTORY_SEPARATOR . self::SCRIPT_TO_RUN_APP_CODE_HOST . '"'
-            . ' "--' . CliScriptAppCodeHost::CLASS_CMD_OPT_NAME . '=' . $testProperties->appCodeClass . '"'
-            . ' "--' . CliScriptAppCodeHost::METHOD_CMD_OPT_NAME . '=' . $testProperties->appCodeMethod . '"',
-            $this->buildEnvVars($testProperties->configSetter->additionalEnvVars())
+            . ' "' . __DIR__ . DIRECTORY_SEPARATOR . self::SCRIPT_TO_RUN_APP_CODE_HOST . '"',
+            $this->buildEnvVars(
+                $testProperties->configSetter->additionalEnvVars() +
+                [
+                    TestConfigUtil::envVarNameForTestsOption(
+                        AllComponentTestsOptionsMetadata::APP_CODE_CLASS_OPTION_NAME
+                    ) => $testProperties->appCodeClass,
+                    TestConfigUtil::envVarNameForTestsOption(
+                        AllComponentTestsOptionsMetadata::APP_CODE_METHOD_OPTION_NAME
+                    ) => $testProperties->appCodeMethod,
+                ]
+            )
         );
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/ConfigSetterEnvVars.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ConfigSetterEnvVars.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Elastic\Apm\Tests\ComponentTests\Util;
 
-use Elastic\Apm\Impl\Config\EnvVarsRawSnapshotSource;
 use Elastic\Apm\Impl\Config\OptionNames;
 use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Tests\Util\TestLogCategory;
@@ -23,6 +22,7 @@ final class ConfigSetterEnvVars extends ConfigSetterBase
             __FILE__
         );
     }
+
     public function appCodePhpCmd(): string
     {
         return self::buildAppCodePhpCmd(AmbientContext::config()->appCodePhpIni());
@@ -38,9 +38,7 @@ final class ConfigSetterEnvVars extends ConfigSetterBase
                 return;
             }
 
-            $envVarName
-                = EnvVarsRawSnapshotSource::optionNameToEnvVarName(EnvVarsRawSnapshotSource::DEFAULT_PREFIX, $optName);
-            $result[$envVarName] = $configuredValue;
+            $result[TestConfigUtil::envVarNameForOption($optName)] = $configuredValue;
         };
 
         $addEnvVarIfOptionIsConfigured(OptionNames::API_KEY, $this->parent->configuredApiKey);

--- a/tests/ElasticApmTests/ComponentTests/Util/ConfigSnapshot.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ConfigSnapshot.php
@@ -16,8 +16,14 @@ final class ConfigSnapshot
 {
     use SnapshotTrait;
 
+    /** @var string|null */
+    private $appCodeClass;
+
     /** @var int */
     private $appCodeHostKind;
+
+    /** @var string|null */
+    private $appCodeMethod;
 
     /** @var string|null */
     private $appCodePhpExe;
@@ -29,13 +35,19 @@ final class ConfigSnapshot
     private $logLevel;
 
     /** @var int */
-    private $mockApmServerPort;
-
-    /** @var int */
-    private $spawnedProcessesCleanerPort;
+    private $resourcesCleanerPort;
 
     /** @var string */
-    private $testEnvId;
+    private $resourcesCleanerServerId;
+
+    /** @var int */
+    private $rootProcessId;
+
+    /** @var int */
+    private $thisServerPort;
+
+    /** @var string */
+    private $thisServerId;
 
     /**
      * Snapshot constructor.
@@ -47,9 +59,19 @@ final class ConfigSnapshot
         $this->setPropertiesToValuesFrom($optNameToParsedValue);
     }
 
+    public function appCodeClass(): ?string
+    {
+        return $this->appCodeClass;
+    }
+
     public function appCodeHostKind(): int
     {
         return $this->appCodeHostKind;
+    }
+
+    public function appCodeMethod(): ?string
+    {
+        return $this->appCodeMethod;
     }
 
     public function appCodePhpExe(): ?string
@@ -67,18 +89,28 @@ final class ConfigSnapshot
         return $this->logLevel;
     }
 
-    public function mockApmServerPort(): int
+    public function resourcesCleanerPort(): int
     {
-        return $this->mockApmServerPort;
+        return $this->resourcesCleanerPort;
     }
 
-    public function spawnedProcessesCleanerPort(): int
+    public function resourcesCleanerServerId(): string
     {
-        return $this->spawnedProcessesCleanerPort;
+        return $this->resourcesCleanerServerId;
     }
 
-    public function testEnvId(): string
+    public function rootProcessId(): int
     {
-        return $this->testEnvId;
+        return $this->rootProcessId;
+    }
+
+    public function thisServerId(): string
+    {
+        return $this->thisServerId;
+    }
+
+    public function thisServerPort(): int
+    {
+        return $this->thisServerPort;
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerProcessTrait.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerProcessTrait.php
@@ -1,56 +1,14 @@
 <?php
 
-/** @noinspection PhpUndefinedClassInspection */
-
 declare(strict_types=1);
 
 namespace Elastic\Apm\Tests\ComponentTests\Util;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Response;
-use RuntimeException;
 
 trait HttpServerProcessTrait
 {
-    /**
-     * @param int                   $port
-     * @param string                $httpMethod
-     * @param string                $uriPath
-     * @param array<string, string> $headers
-     *
-     * @return ResponseInterface
-     *
-     * @throws GuzzleException
-     * @noinspection PhpDocRedundantThrowsInspection
-     */
-    public static function sendRequest(
-        int $port,
-        string $httpMethod,
-        string $uriPath,
-        array $headers
-    ): ResponseInterface {
-        $client = new Client(['base_uri' => "http://localhost:$port"]);
-        return $client->request($httpMethod, $uriPath, [RequestOptions::HEADERS => $headers]);
-    }
-
-    public static function sendRequestToCheckStatus(int $port, string $testEnvId, string $dbgServerDesc): void
-    {
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $response = self::sendRequest(
-            $port,
-            HttpConsts::METHOD_GET,
-            TestEnvBase::STATUS_CHECK_URI,
-            [TestEnvBase::TEST_ENV_ID_HEADER_NAME => $testEnvId]
-        );
-
-        if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
-            throw new RuntimeException("Received unexpected status code in response to status check to $dbgServerDesc");
-        }
-    }
-
     /**
      * @param callable $getRequestHeaderFunc
      *
@@ -58,14 +16,14 @@ trait HttpServerProcessTrait
      *
      * @phpstan-param callable(string): string $getRequestHeaderFunc
      */
-    protected static function verifyTestEnvIdEx(callable $getRequestHeaderFunc): ResponseInterface
+    protected static function verifyServerIdEx(callable $getRequestHeaderFunc): ResponseInterface
     {
-        $receivedTestEnvId = $getRequestHeaderFunc(TestEnvBase::TEST_ENV_ID_HEADER_NAME);
-        if ($receivedTestEnvId !== AmbientContext::config()->testEnvId()) {
+        $receivedServerId = $getRequestHeaderFunc(TestEnvBase::SERVER_ID_HEADER_NAME);
+        if ($receivedServerId !== AmbientContext::config()->thisServerId()) {
             return self::buildErrorResponse(
                 400,
-                'Received test env ID does not match the expected one.'
-                . ' Expected: ' . AmbientContext::config()->testEnvId() . ', received: ' . $receivedTestEnvId
+                'Received server ID does not match the expected one.'
+                . ' Expected: ' . AmbientContext::config()->thisServerId() . ', received: ' . $receivedServerId
             );
         }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
@@ -17,8 +17,11 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
     /** @var Logger */
     private $logger;
 
-    /** @var int */
-    protected $appCodeHostServerPort;
+    /** @var string|null */
+    protected $appCodeHostServerId = null;
+
+    /** @var int|null */
+    protected $appCodeHostServerPort = null;
 
     public function __construct()
     {
@@ -44,12 +47,13 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
         );
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $response = BuiltinHttpServerAppCodeHost::sendRequest(
+        /** @phpstan-ignore-next-line - Call to static method ... on trait */
+        $response = TestHttpClientUtil::sendHttpRequest(
             $this->appCodeHostServerPort,
+            $this->appCodeHostServerId,
             $testProperties->httpMethod,
             $testProperties->uriPath,
             [
-                self::TEST_ENV_ID_HEADER_NAME => $this->testEnvId(),
                 BuiltinHttpServerAppCodeHost::CLASS_HEADER_NAME  => $testProperties->appCodeClass,
                 BuiltinHttpServerAppCodeHost::METHOD_HEADER_NAME => $testProperties->appCodeMethod,
             ]

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerTestEnvBase.php
@@ -39,6 +39,8 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
     {
         $this->ensureMockApmServerRunning();
         $this->ensureAppCodeHostServerRunning($testProperties);
+        TestCase::assertNotNull($this->appCodeHostServerPort);
+        TestCase::assertNotNull($this->appCodeHostServerId);
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(
@@ -46,8 +48,6 @@ abstract class HttpServerTestEnvBase extends TestEnvBase
             . ' to ' . DbgUtil::fqToShortClassName(BuiltinHttpServerAppCodeHost::class) . '...'
         );
 
-        /** @noinspection PhpUnhandledExceptionInspection */
-        /** @phpstan-ignore-next-line - Call to static method ... on trait */
         $response = TestHttpClientUtil::sendHttpRequest(
             $this->appCodeHostServerPort,
             $this->appCodeHostServerId,

--- a/tests/ElasticApmTests/ComponentTests/Util/MockApmServer.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/MockApmServer.php
@@ -17,14 +17,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Response;
 use React\Promise\Promise;
-use RuntimeException;
 
 final class MockApmServer extends StatefulHttpServerProcessBase
 {
-    private const MOCK_API_URI_PREFIX = '/mock_apm_server_api/';
+    public const MOCK_API_URI_PREFIX = '/mock_apm_server_api/';
     private const INTAKE_API_URI = '/intake/v2/events';
-    private const GET_INTAKE_API_REQUESTS = 'get_intake_api_requests';
-    private const FROM_INDEX_HEADER_NAME = TestEnvBase::HEADER_NAME_PREFIX . 'FROM_INDEX';
+    public const GET_INTAKE_API_REQUESTS = 'get_intake_api_requests';
+    public const FROM_INDEX_HEADER_NAME = TestEnvBase::HEADER_NAME_PREFIX . 'FROM_INDEX';
     public const INTAKE_API_REQUESTS_JSON_KEY = 'intake_api_requests_received_from_agent';
 
     /** @var int */
@@ -56,29 +55,6 @@ final class MockApmServer extends StatefulHttpServerProcessBase
         )->addContext('this', $this);
     }
 
-    public static function sendRequestToGetAgentIntakeApiRequests(
-        int $port,
-        string $testEnvId,
-        int $fromIndex
-    ): ResponseInterface {
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $response = self::sendRequest(
-            $port,
-            HttpConsts::METHOD_GET,
-            self::MOCK_API_URI_PREFIX . self::GET_INTAKE_API_REQUESTS,
-            [
-                TestEnvBase::TEST_ENV_ID_HEADER_NAME => $testEnvId,
-                self::FROM_INDEX_HEADER_NAME         => strval($fromIndex),
-            ]
-        );
-
-        if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
-            throw new RuntimeException('Received unexpected status code');
-        }
-
-        return $response;
-    }
-
     protected function beforeLoopRun(LoopInterface $loop): void
     {
         $this->reactLoop = $loop;
@@ -102,7 +78,7 @@ final class MockApmServer extends StatefulHttpServerProcessBase
         return $this->buildErrorResponse(/* status */ 400, 'Unknown API path: `' . $request->getRequestTarget() . '\'');
     }
 
-    protected function shouldHaveTestEnvId(ServerRequestInterface $request): bool
+    protected function shouldRequestHaveServerId(ServerRequestInterface $request): bool
     {
         return $request->getUri()->getPath() !== self::INTAKE_API_URI;
     }

--- a/tests/ElasticApmTests/ComponentTests/Util/ResourcesCleaner.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ResourcesCleaner.php
@@ -8,24 +8,19 @@ namespace Elastic\Apm\Tests\ComponentTests\Util;
 
 use Ds\Set;
 use Elastic\Apm\Impl\Log\Logger;
-use Elastic\Apm\Impl\Util\DbgUtil;
 use Elastic\Apm\Impl\Util\ObjectToStringBuilder;
 use Elastic\Apm\Tests\Util\TestLogCategory;
-use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Response;
-use RuntimeException;
 
-final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
+final class ResourcesCleaner extends StatefulHttpServerProcessBase
 {
-    public const PARENT_PID_CMD_OPT_NAME = 'parent_pid';
+    public const REGISTER_PROCESS_TO_TERMINATE_URI_PATH = '/register_process_to_terminate';
+    public const CLEAN_AND_EXIT_URI_PATH = '/clean_resources_and_exit';
 
-    private const REGISTER_URI_PATH = '/terminate_process_on_parent_exit';
-    public const CLEAN_AND_EXIT_URI_PATH = '/clean_spawned_processes_and_exit';
-
-    private const PID_QUERY_HEADER_NAME = TestEnvBase::HEADER_NAME_PREFIX . 'PID';
+    public const PID_QUERY_HEADER_NAME = TestEnvBase::HEADER_NAME_PREFIX . 'PID';
 
     /** @var LoopInterface */
     protected $loop;
@@ -34,10 +29,10 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
     private $logger;
 
     /** @var int */
-    private $parentPid;
+    private $rootProcessId;
 
     /** @var Set<int> */
-    private $spawnedProcessesIds;
+    private $processesToTerminateIds;
 
     public function __construct(string $runScriptFile)
     {
@@ -50,52 +45,18 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
             __FILE__
         )->addContext('this', $this);
 
-        $this->spawnedProcessesIds = new Set();
+        $this->processesToTerminateIds = new Set();
     }
 
-    public static function sendRequestToRegisterProcess(int $port, string $testEnvId, int $pid): void
+    protected function processConfig(): void
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $response = self::sendRequest(
-            $port,
-            HttpConsts::METHOD_POST,
-            self::REGISTER_URI_PATH,
-            [
-                TestEnvBase::TEST_ENV_ID_HEADER_NAME => $testEnvId,
-                self::PID_QUERY_HEADER_NAME          => strval($pid),
-            ]
+        parent::processConfig();
+
+        $this->rootProcessId = intval(
+            self::getRequiredTestOption(
+                AllComponentTestsOptionsMetadata::ROOT_PROCESS_ID_OPTION_NAME
+            )
         );
-
-        if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
-            throw new RuntimeException(
-                'Failed to register with '
-                . DbgUtil::fqToShortClassName(SpawnedProcessesCleaner::class)
-            );
-        }
-    }
-
-    protected function cliHelpOptions(): string
-    {
-        return parent::cliHelpOptions()
-               . ' --' . self::PARENT_PID_CMD_OPT_NAME . /** @lang text */ '=<parent PID>';
-    }
-
-    protected function parseArgs(): void
-    {
-        parent::parseArgs();
-
-        $longOpts = [];
-
-        // --parent-pid=98765 - required value
-        $longOpts[] = SpawnedProcessesCleaner::PARENT_PID_CMD_OPT_NAME . ':';
-
-        $parsedCliOptions = getopt(/* shortOpts */ '', $longOpts);
-
-        $parentPidAsString = $this->checkRequiredCliOption(
-            SpawnedProcessesCleaner::PARENT_PID_CMD_OPT_NAME,
-            $parsedCliOptions
-        );
-        $this->parentPid = intval($parentPidAsString);
     }
 
     protected function beforeLoopRun(LoopInterface $loop): void
@@ -103,28 +64,13 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
         $loop->addPeriodicTimer(
             1 /* interval in seconds */,
             function () {
-                if (!TestProcessUtil::doesProcessExist($this->parentPid)) {
+                if (!TestProcessUtil::doesProcessExist($this->rootProcessId)) {
                     ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
                     && $loggerProxy->log('Detected that parent process does not exist');
                     $this->cleanAndExit();
                 }
             }
         );
-    }
-
-    public static function sendRequestToCleanAndExit(int $port, string $testEnvId): void
-    {
-        try {
-            self::sendRequest(
-                $port,
-                HttpConsts::METHOD_POST,
-                self::CLEAN_AND_EXIT_URI_PATH,
-                [TestEnvBase::TEST_ENV_ID_HEADER_NAME => $testEnvId]
-            );
-        } /** @noinspection PhpUndefinedClassInspection */ catch (GuzzleException $ex) {
-            // clean-and-exit request is expected to throw
-            // because SpawnedProcessesCleaner process exits before responding
-        }
     }
 
     private function cleanAndExit(): void
@@ -138,7 +84,7 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
 
     private function cleanSpawnedProcesses(): void
     {
-        if ($this->spawnedProcessesIds->isEmpty()) {
+        if ($this->processesToTerminateIds->isEmpty()) {
             ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
             && $loggerProxy->log('There are no spawned processes to terminate');
             return;
@@ -147,10 +93,10 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(
             'Terminating spawned processes...',
-            ['spawnedProcessesCount' => $this->spawnedProcessesIds->count()]
+            ['spawnedProcessesCount' => $this->processesToTerminateIds->count()]
         );
 
-        foreach ($this->spawnedProcessesIds as $spawnedProcessesId) {
+        foreach ($this->processesToTerminateIds as $spawnedProcessesId) {
             if (!TestProcessUtil::doesProcessExist($spawnedProcessesId)) {
                 ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
                 && $loggerProxy->log(
@@ -170,7 +116,7 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
 
     protected function processRequest(ServerRequestInterface $request): ResponseInterface
     {
-        if ($request->getUri()->getPath() === self::REGISTER_URI_PATH) {
+        if ($request->getUri()->getPath() === self::REGISTER_PROCESS_TO_TERMINATE_URI_PATH) {
             return $this->registerProcessToTerminate($request);
         } elseif ($request->getUri()->getPath() === self::CLEAN_AND_EXIT_URI_PATH) {
             $this->cleanAndExit();
@@ -184,17 +130,17 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
     protected function registerProcessToTerminate(ServerRequestInterface $request): ResponseInterface
     {
         $pid = intval(self::getRequestHeader($request, self::PID_QUERY_HEADER_NAME));
-        $this->spawnedProcessesIds->add($pid);
+        $this->processesToTerminateIds->add($pid);
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(
             'Successfully registered process to terminate',
-            ['pid' => $pid, 'spawnedProcessesCount' => $this->spawnedProcessesIds->count()]
+            ['pid' => $pid, 'spawnedProcessesCount' => $this->processesToTerminateIds->count()]
         );
 
         return new Response(HttpConsts::STATUS_OK);
     }
 
-    protected function shouldRegisterWithSpawnedProcessesCleaner(): bool
+    protected function shouldRegisterThisProcessWithResourcesCleaner(): bool
     {
         return false;
     }
@@ -202,6 +148,6 @@ final class SpawnedProcessesCleaner extends StatefulHttpServerProcessBase
     protected function toStringAddProperties(ObjectToStringBuilder $builder): void
     {
         parent::toStringAddProperties($builder);
-        $builder->add('parentPid', $this->parentPid);
+        $builder->add('parentPid', $this->rootProcessId);
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
@@ -108,8 +108,9 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
     {
     }
 
-    protected function shouldRequestHaveServerId(ServerRequestInterface $request): bool
-    {
+    protected function shouldRequestHaveServerId(
+        /** @noinspection PhpUnusedParameterInspection */ ServerRequestInterface $request
+    ): bool {
         return true;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
@@ -8,6 +8,7 @@ use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\Util\DbgUtil;
 use Elastic\Apm\Impl\Util\ObjectToStringBuilder;
 use Elastic\Apm\Tests\Util\TestLogCategory;
+use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
@@ -22,16 +23,14 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
 {
     use HttpServerProcessTrait;
 
-    public const PORT_CMD_OPT_NAME = 'port';
+    /** @var Logger */
+    private $logger;
 
     /** @var string */
     protected $runScriptFile;
 
     /** @var int */
     protected $port;
-
-    /** @var Logger */
-    private $logger;
 
     public function __construct(string $runScriptFile)
     {
@@ -45,22 +44,17 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
         )->addContext('this', $this);
     }
 
-    protected function cliHelpOptions(): string
+    protected function processConfig(): void
     {
-        return ' --' . self::PORT_CMD_OPT_NAME . /** @lang text */ '=<port number>';
-    }
+        parent::processConfig();
 
-    protected function parseArgs(): void
-    {
-        $longOpts = [];
+        $this->port = intval(
+            self::getRequiredTestOption(
+                AllComponentTestsOptionsMetadata::THIS_SERVER_PORT_OPTION_NAME
+            )
+        );
 
-        // --port=12345 - required value
-        $longOpts[] = self::PORT_CMD_OPT_NAME . ':';
-
-        $parsedCliOptions = getopt(/* shortOpts */ '', $longOpts);
-
-        $portAsString = $this->checkRequiredCliOption(self::PORT_CMD_OPT_NAME, $parsedCliOptions);
-        $this->port = intval($portAsString);
+        self::getRequiredTestOption(AllComponentTestsOptionsMetadata::THIS_SERVER_ID_OPTION_NAME);
     }
 
     /**
@@ -72,7 +66,12 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
 
     protected function runImpl(): void
     {
-        $this->runHttpServer($this->port);
+        try {
+            $this->runHttpServer($this->port);
+        } catch (Exception $ex) {
+            ($loggerProxy = $this->logger->ifNoticeLevelEnabled(__LINE__, __FUNCTION__))
+            && $loggerProxy->logThrowable($ex, 'Failed to start HTTP server - exiting...');
+        }
     }
 
     private function runHttpServer(int $port): void
@@ -109,7 +108,7 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
     {
     }
 
-    protected function shouldHaveTestEnvId(ServerRequestInterface $request): bool
+    protected function shouldRequestHaveServerId(ServerRequestInterface $request): bool
     {
         return true;
     }
@@ -161,8 +160,8 @@ abstract class StatefulHttpServerProcessBase extends CliProcessBase
      */
     private function processRequestWrapperImpl(ServerRequestInterface $request)
     {
-        if ($this->shouldHaveTestEnvId($request)) {
-            $verifyTestEnvIdResponse = self::verifyTestEnvIdEx(
+        if ($this->shouldRequestHaveServerId($request)) {
+            $verifyTestEnvIdResponse = self::verifyServerIdEx(
                 function (string $headerName) use ($request): string {
                     return self::getRequestHeader($request, $headerName);
                 }

--- a/tests/ElasticApmTests/ComponentTests/Util/TestConfigUtil.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestConfigUtil.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Tests\ComponentTests\Util;
+
+use Elastic\Apm\Impl\Config\EnvVarsRawSnapshotSource;
+use Elastic\Apm\Impl\Util\StaticClassTrait;
+
+final class TestConfigUtil
+{
+    use StaticClassTrait;
+
+    public const ENV_VAR_NAME_PREFIX = 'ELASTIC_APM_TESTS_';
+
+    public static function envVarNameForOption(string $optName): string
+    {
+        return EnvVarsRawSnapshotSource::optionNameToEnvVarName(
+            EnvVarsRawSnapshotSource::DEFAULT_NAME_PREFIX,
+            $optName
+        );
+    }
+
+    public static function envVarNameForTestsOption(string $optName): string
+    {
+        return EnvVarsRawSnapshotSource::optionNameToEnvVarName(self::ENV_VAR_NAME_PREFIX, $optName);
+    }
+}

--- a/tests/ElasticApmTests/ComponentTests/Util/TestEnvBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestEnvBase.php
@@ -1,23 +1,26 @@
 <?php
 
+/** @noinspection PhpUndefinedClassInspection */
+
 declare(strict_types=1);
 
 namespace Elastic\Apm\Tests\ComponentTests\Util;
 
 use Closure;
 use Elastic\Apm\Impl\Clock;
-use Elastic\Apm\Impl\Config\EnvVarsRawSnapshotSource;
 use Elastic\Apm\Impl\Config\OptionNames;
 use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\MetadataDiscoverer;
 use Elastic\Apm\Impl\Tracer;
 use Elastic\Apm\Impl\Util\DbgUtil;
+use Elastic\Apm\Impl\Util\IdGenerator;
 use Elastic\Apm\Impl\Util\ObjectToStringBuilder;
 use Elastic\Apm\Tests\Util\TestCaseBase;
 use Elastic\Apm\Tests\Util\TestLogCategory;
 use Elastic\Apm\TransactionDataInterface;
 use Exception;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Exception as PhpUnitException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -28,25 +31,28 @@ abstract class TestEnvBase
     private const PORTS_RANGE_BEGIN = 50000;
     private const PORTS_RANGE_END = 60000;
 
+    private const MAX_WAIT_SERVER_START_MICROSECONDS = 10 * 1000 * 1000; // 10 seconds
+    private const MAX_TRIES_TO_START_SERVER = 3;
+
     public const STATUS_CHECK_URI = '/elastic_apm_php_tests_status_check';
     public const HEADER_NAME_PREFIX = 'ELASTIC_APM_PHP_TESTS_';
-    public const TEST_ENV_ID_HEADER_NAME = self::HEADER_NAME_PREFIX . 'TEST_ENV_ID';
+    public const SERVER_ID_HEADER_NAME = self::HEADER_NAME_PREFIX . 'SERVER_ID';
 
     public const DATA_FROM_AGENT_MAX_WAIT_TIME_SECONDS = 10;
 
     private const AUTH_HTTP_HEADER_NAME = 'Authorization';
-
     /** @var int|null */
-    protected $spawnedProcessesCleanerPort = null;
-
+    protected $resourcesCleanerPort = null;
+    /** @var string|null */
+    protected $resourcesCleanerServerId = null;
+    /** @var string|null */
+    protected $mockApmServerId = null;
     /** @var Logger */
     private $logger;
-
-    /** @var int|null */
-    private $mockApmServerPort = null;
-
     /** @var DataFromAgent */
     private $dataFromAgent;
+    /** @var int|null */
+    private $mockApmServerPort = null;
 
     public function __construct()
     {
@@ -65,93 +71,164 @@ abstract class TestEnvBase
         return PhpUnitExtension::$testEnvId;
     }
 
-    protected function ensureMockApmServerRunning(): void
-    {
-        $this->ensureSpawnedProcessesCleanerRunning();
-
-        if (!is_null($this->mockApmServerPort)) {
-            return;
-        }
-
-        $mockApmServerPort
-            = AmbientContext::config()->mockApmServerPort() === AllComponentTestsOptionsMetadata::INT_OPTION_NOT_SET
-                ? $this->findFreePortToListen()
-                : AmbientContext::config()->mockApmServerPort();
-
-        ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
-        && $loggerProxy->log(
-            'Starting ' . DbgUtil::fqToShortClassName(MockApmServer::class) . '...',
-            ['mockApmServerPort' => $mockApmServerPort]
-        );
-        TestProcessUtil::startBackgroundProcess(
-            "php"
-            . ' "' . __DIR__ . DIRECTORY_SEPARATOR . 'runMockApmServer.php"'
-            . ' --' . StatefulHttpServerProcessBase::PORT_CMD_OPT_NAME . '=' . $mockApmServerPort,
-            $this->buildEnvVars()
-        );
-        $this->ensureHttpServerRunning(
-            $mockApmServerPort,
-            /* dbgServerDesc */ DbgUtil::fqToShortClassName(MockApmServer::class)
-        );
-
-        $this->mockApmServerPort = $mockApmServerPort;
-    }
-
     protected function findFreePortToListen(): int
     {
         return mt_rand(self::PORTS_RANGE_BEGIN, self::PORTS_RANGE_END - 1);
     }
 
-    private function ensureSpawnedProcessesCleanerRunning(): void
+    protected function isHttpServerRunning(int $port, string $serverId, string $dbgServerDesc): bool
     {
-        if (!is_null($this->spawnedProcessesCleanerPort)) {
-            return;
-        }
-
-        $spawnedProcessesCleanerPort = $this->findFreePortToListen();
-
-        ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
-        && $loggerProxy->log(
-            'Starting ' . DbgUtil::fqToShortClassName(SpawnedProcessesCleaner::class) . '...',
-            ['spawnedProcessesCleanerPort' => $spawnedProcessesCleanerPort]
-        );
-        TestProcessUtil::startBackgroundProcess(
-            "php"
-            . ' "' . __DIR__ . '/runSpawnedProcessesCleaner.php"'
-            . ' --' . StatefulHttpServerProcessBase::PORT_CMD_OPT_NAME . '=' . $spawnedProcessesCleanerPort
-            . ' --' . SpawnedProcessesCleaner::PARENT_PID_CMD_OPT_NAME . '=' . getmypid(),
-            $this->buildEnvVars()
-        );
-        $this->ensureHttpServerRunning(
-            $spawnedProcessesCleanerPort,
-            /* dbgServerDesc */ DbgUtil::fqToShortClassName(SpawnedProcessesCleaner::class)
-        );
-        $this->spawnedProcessesCleanerPort = $spawnedProcessesCleanerPort;
-    }
-
-    protected function ensureHttpServerRunning(int $port, string $dbgServerDesc): void
-    {
-        $checkRetVal = (new PollingCheck(
+        return (new PollingCheck(
             $dbgServerDesc . ' started',
-            10 * 1000 * 1000 /* maxWaitTimeInMicroseconds - 10 seconds */,
+            self::MAX_WAIT_SERVER_START_MICROSECONDS,
             AmbientContext::loggerFactory()
         ))->run(
-            function () use ($port, $dbgServerDesc) {
+            function () use ($port, $serverId, $dbgServerDesc) {
+                $logger = AmbientContext::loggerFactory()->loggerForClass(
+                    TestLogCategory::TEST_UTIL,
+                    __NAMESPACE__,
+                    __CLASS__,
+                    __FILE__
+                )->addAllContext(['dbgServerDesc' => $dbgServerDesc, 'port' => $port, 'serverId' => $serverId]);
+
                 try {
-                    /** @phpstan-ignore-next-line */
-                    HttpServerProcessTrait::sendRequestToCheckStatus($port, $this->testEnvId(), $dbgServerDesc);
-                } catch (ConnectException $ex) {
+                    $response = TestHttpClientUtil::sendHttpRequest(
+                        $port,
+                        $serverId,
+                        HttpConsts::METHOD_GET,
+                        TestEnvBase::STATUS_CHECK_URI
+                    );
+                } catch (Throwable $throwable) {
+                    ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+                    && $loggerProxy->logThrowable($throwable, 'Failed to send request to check HTTP server status');
                     return false;
                 }
+
+                if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
+                    ($loggerProxy = $logger->ifNoticeLevelEnabled(__LINE__, __FUNCTION__))
+                    && $loggerProxy->log(
+                        'Received non-OK status code in response to status check',
+                        ['receivedStatusCode' => $response->getStatusCode()]
+                    );
+                    return false;
+                }
+
+                ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+                && $loggerProxy->log('HTTP server status is OK');
                 return true;
             }
         );
+    }
 
-        if ($checkRetVal) {
+    /**
+     * @param int|null              $port
+     * @param string|null           $serverId
+     * @param string                $dbgServerDesc
+     * @param Closure               $cmdLineGenFunc
+     * @param array<string, string> $additionalEnvVars
+     *
+     * @phpstan-param   Closure(int $port): string $cmdLineGenFunc
+     */
+    protected function ensureHttpServerIsRunning(
+        ?int &$port,
+        ?string &$serverId,
+        string $dbgServerDesc,
+        Closure $cmdLineGenFunc,
+        array $additionalEnvVars = []
+    ): void {
+        if (!is_null($port)) {
+            TestCase::assertNotNull($serverId);
             return;
         }
+        TestCase::assertNull($serverId);
 
-        throw new RuntimeException("HTTP Server is not running. dbgServerDesc: $dbgServerDesc. port: $port.");
+        /** @var int|null */
+        $currentTryPort = null;
+        for ($tryCount = 0; $tryCount < self::MAX_TRIES_TO_START_SERVER; ++$tryCount) {
+            $currentTryPort = $this->findFreePortToListen();
+            $currentTryServerId = $this->testEnvId() . '_' . IdGenerator::generateId(/* idLengthInBytes */ 16);
+            $cmdLine = $cmdLineGenFunc($currentTryPort);
+
+            $logger = $this->logger->inherit()->addAllContext(
+                [
+                    'tryCount'           => $tryCount,
+                    'maxTries'           => self::MAX_TRIES_TO_START_SERVER,
+                    'dbgServerDesc'      => $dbgServerDesc,
+                    'currentTryPort'     => $currentTryPort,
+                    'currentTryServerId' => $currentTryServerId,
+                    'cmdLine'            => $cmdLine,
+                ]
+            );
+
+            ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+            && $loggerProxy->log('Starting HTTP server...');
+
+            TestProcessUtil::startBackgroundProcess(
+                $cmdLine,
+                $this->buildEnvVars(
+                    $additionalEnvVars +
+                    [
+                        TestConfigUtil::envVarNameForTestsOption(
+                            AllComponentTestsOptionsMetadata::THIS_SERVER_PORT_OPTION_NAME
+                        ) => strval($currentTryPort),
+                        TestConfigUtil::envVarNameForTestsOption(
+                            AllComponentTestsOptionsMetadata::THIS_SERVER_ID_OPTION_NAME
+                        ) => $currentTryServerId,
+                    ]
+                )
+            );
+
+            if (self::isHttpServerRunning($currentTryPort, $currentTryServerId, $dbgServerDesc)) {
+                ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+                && $loggerProxy->log('Started HTTP server');
+                $port = $currentTryPort;
+                $serverId = $currentTryServerId;
+                return;
+            }
+
+            ($loggerProxy = $logger->ifNoticeLevelEnabled(__LINE__, __FUNCTION__))
+            && $loggerProxy->log('Failed to start HTTP server');
+        }
+
+        throw new RuntimeException("Failed to start HTTP server. dbgServerDesc: $dbgServerDesc.");
+    }
+
+    private static function runScriptNameToCmdLine(string $runScriptName): string
+    {
+        return 'php ' . '"' . __DIR__ . DIRECTORY_SEPARATOR . $runScriptName . '"';
+    }
+
+    private function ensureResourcesCleanerRunning(): void
+    {
+        $this->ensureHttpServerIsRunning(
+            $this->resourcesCleanerPort /* <- ref */,
+            $this->resourcesCleanerServerId /* <- ref */,
+            DbgUtil::fqToShortClassName(ResourcesCleaner::class) /* <- dbgServerDesc */,
+            /* cmdLineGenFunc: */
+            function (/** @noinspection PhpUnusedParameterInspection */ int $port) {
+                return self::runScriptNameToCmdLine('runResourcesCleaner.php');
+            },
+            /* additionalEnvVars */
+            [
+                TestConfigUtil::envVarNameForTestsOption(AllComponentTestsOptionsMetadata::ROOT_PROCESS_ID_OPTION_NAME)
+                => strval(getmypid()),
+            ]
+        );
+    }
+
+    protected function ensureMockApmServerRunning(): void
+    {
+        $this->ensureResourcesCleanerRunning();
+
+        $this->ensureHttpServerIsRunning(
+            $this->mockApmServerPort /* <- ref */,
+            $this->mockApmServerId /* <- ref */,
+            DbgUtil::fqToShortClassName(MockApmServer::class) /* <- dbgServerDesc */,
+            /* cmdLineGenFunc: */
+            function (/** @noinspection PhpUnusedParameterInspection */ int $port) {
+                return self::runScriptNameToCmdLine('runMockApmServer.php');
+            }
+        );
     }
 
     /**
@@ -159,7 +236,7 @@ abstract class TestEnvBase
      *
      * @return array<string, string>
      */
-    protected function buildEnvVars(array $additionalEnvVars = []): array
+    public function buildEnvVars(array $additionalEnvVars): array
     {
         ($loggerProxy = $this->logger->ifTraceLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Entered', ['additionalEnvVars' => $additionalEnvVars]);
@@ -168,28 +245,23 @@ abstract class TestEnvBase
         $result = getenv();
 
         if (!is_null($this->mockApmServerPort)) {
-            $result[EnvVarsRawSnapshotSource::optionNameToEnvVarName(
-                EnvVarsRawSnapshotSource::DEFAULT_PREFIX,
-                OptionNames::SERVER_URL
-            )]
+            $result[TestConfigUtil::envVarNameForOption(OptionNames::SERVER_URL)]
                 = 'http://localhost:' . $this->mockApmServerPort;
         }
 
-        if (!is_null($this->spawnedProcessesCleanerPort)) {
-            $result[EnvVarsRawSnapshotSource::optionNameToEnvVarName(
-                AmbientContext::ENV_VAR_NAME_PREFIX,
-                AllComponentTestsOptionsMetadata::SPAWNED_PROCESSES_CLEANER_PORT_OPTION_NAME
+        if (!is_null($this->resourcesCleanerPort)) {
+            $result[TestConfigUtil::envVarNameForTestsOption(
+                AllComponentTestsOptionsMetadata::RESOURCES_CLEANER_PORT_OPTION_NAME
             )]
-                = strval($this->spawnedProcessesCleanerPort);
+                = strval($this->resourcesCleanerPort);
+            TestCase::assertNotNull($this->resourcesCleanerServerId);
+            $result[TestConfigUtil::envVarNameForTestsOption(
+                AllComponentTestsOptionsMetadata::RESOURCES_CLEANER_SERVER_ID_OPTION_NAME
+            )]
+                = $this->resourcesCleanerServerId;
         }
 
-        $result[EnvVarsRawSnapshotSource::optionNameToEnvVarName(
-            AmbientContext::ENV_VAR_NAME_PREFIX,
-            AllComponentTestsOptionsMetadata::TEST_ENV_ID_OPTION_NAME
-        )]
-            = $this->testEnvId();
-
-        $result = array_merge($result, $additionalEnvVars);
+        $result += $additionalEnvVars;
 
         ($loggerProxy = $this->logger->ifTraceLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Exiting', ['result' => $result]);
@@ -226,25 +298,36 @@ abstract class TestEnvBase
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Shutting down...');
 
-        $this->signalSpawnedProcessesCleanerToExit();
+        $this->signalResourcesCleanerToExit();
     }
 
-    private function signalSpawnedProcessesCleanerToExit(): void
+    private function signalResourcesCleanerToExit(): void
     {
-        if (is_null($this->spawnedProcessesCleanerPort)) {
+        if (is_null($this->resourcesCleanerPort)) {
             return;
+        }
+        TestCase::assertNotNull($this->resourcesCleanerServerId);
+
+        ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+        && $loggerProxy->log(
+            'Signaling ' . DbgUtil::fqToShortClassName(ResourcesCleaner::class) . ' to clean and exit...'
+        );
+
+        try {
+            TestHttpClientUtil::sendHttpRequest(
+                $this->resourcesCleanerPort,
+                $this->resourcesCleanerServerId,
+                HttpConsts::METHOD_POST,
+                ResourcesCleaner::CLEAN_AND_EXIT_URI_PATH
+            );
+        } catch (GuzzleException $ex) {
+            // clean-and-exit request is expected to throw
+            // because ResourcesCleaner process exits before responding
         }
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log(
-            'Signaling ' . DbgUtil::fqToShortClassName(SpawnedProcessesCleaner::class) . ' to clean and exit...'
-        );
-
-        SpawnedProcessesCleaner::sendRequestToCleanAndExit($this->spawnedProcessesCleanerPort, $this->testEnvId());
-
-        ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
-        && $loggerProxy->log(
-            'Signaled ' . DbgUtil::fqToShortClassName(SpawnedProcessesCleaner::class) . ' to clean and exit'
+            'Signaled ' . DbgUtil::fqToShortClassName(ResourcesCleaner::class) . ' to clean and exit'
         );
     }
 
@@ -373,7 +456,7 @@ abstract class TestEnvBase
         }
 
         $expectedAuthHeaderValue = is_null($expectedApiKey)
-            ? ( is_null($expectedSecretToken) ? null : "Bearer $expectedSecretToken")
+            ? (is_null($expectedSecretToken) ? null : "Bearer $expectedSecretToken")
             : "ApiKey $expectedApiKey";
 
         foreach ($dataFromAgent->intakeApiRequests as $intakeApiRequest) {
@@ -446,12 +529,20 @@ abstract class TestEnvBase
     private function fetchLatestDataFromMockApmServer(): array
     {
         TestCase::assertNotNull($this->mockApmServerPort);
+        TestCase::assertNotNull($this->mockApmServerId);
 
-        $response = MockApmServer::sendRequestToGetAgentIntakeApiRequests(
+        $response = TestHttpClientUtil::sendHttpRequest(
             $this->mockApmServerPort,
-            $this->testEnvId(),
-            $this->dataFromAgent->nextIntakeApiRequestIndexToFetch()
+            $this->mockApmServerId,
+            HttpConsts::METHOD_GET,
+            MockApmServer::MOCK_API_URI_PREFIX . MockApmServer::GET_INTAKE_API_REQUESTS,
+            [MockApmServer::FROM_INDEX_HEADER_NAME => strval($this->dataFromAgent->nextIntakeApiRequestIndexToFetch())]
         );
+
+        if ($response->getStatusCode() !== HttpConsts::STATUS_OK) {
+            throw new RuntimeException('Received unexpected status code');
+        }
+
         $decodedBody = json_decode($response->getBody()->getContents(), /* assoc */ true);
 
         $requestsJson = $decodedBody[MockApmServer::INTAKE_API_REQUESTS_JSON_KEY];

--- a/tests/ElasticApmTests/ComponentTests/Util/TestEnvBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestEnvBase.php
@@ -41,16 +41,22 @@ abstract class TestEnvBase
     public const DATA_FROM_AGENT_MAX_WAIT_TIME_SECONDS = 10;
 
     private const AUTH_HTTP_HEADER_NAME = 'Authorization';
+
     /** @var int|null */
     protected $resourcesCleanerPort = null;
+
     /** @var string|null */
     protected $resourcesCleanerServerId = null;
+
     /** @var string|null */
     protected $mockApmServerId = null;
+
     /** @var Logger */
     private $logger;
+
     /** @var DataFromAgent */
     private $dataFromAgent;
+
     /** @var int|null */
     private $mockApmServerPort = null;
 

--- a/tests/ElasticApmTests/ComponentTests/Util/TestHttpClientUtil.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestHttpClientUtil.php
@@ -1,0 +1,45 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Tests\ComponentTests\Util;
+
+use Elastic\Apm\Impl\Util\StaticClassTrait;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+
+final class TestHttpClientUtil
+{
+    use StaticClassTrait;
+
+    /**
+     * @param int                   $port
+     * @param string                $serverId
+     * @param string                $httpMethod
+     * @param string                $uriPath
+     * @param array<string, string> $headers
+     *
+     * @return ResponseInterface
+     *
+     * @throws GuzzleException
+     * @noinspection PhpDocRedundantThrowsInspection
+     */
+    public static function sendHttpRequest(
+        int $port,
+        string $serverId,
+        string $httpMethod,
+        string $uriPath,
+        array $headers = []
+    ): ResponseInterface {
+        $client = new Client(['base_uri' => "http://localhost:$port"]);
+        return $client->request(
+            $httpMethod,
+            $uriPath,
+            [RequestOptions::HEADERS => $headers + [TestEnvBase::SERVER_ID_HEADER_NAME => $serverId]]
+        );
+    }
+}

--- a/tests/ElasticApmTests/ComponentTests/Util/runResourcesCleaner.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/runResourcesCleaner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../../bootstrap.php';
 
-use Elastic\Apm\Tests\ComponentTests\Util\SpawnedProcessesCleaner;
+use Elastic\Apm\Tests\ComponentTests\Util\ResourcesCleaner;
 
 /** @noinspection PhpUnhandledExceptionInspection */
-SpawnedProcessesCleaner::run(__FILE__);
+ResourcesCleaner::run(__FILE__);


### PR DESCRIPTION
To handle the situation when randomly selected port is already used add retry for starting HTTP servers used for testing (mock APM Server, etc.)