### PR TITLE
[CI] test signed binaries and released binaries

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -383,7 +383,7 @@ pipeline {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replace('^v', '')} -C packaging install-release", label: 'package install-release'
+                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replaceAll('^v', '')} -C packaging install-release", label: 'package install-release'
                     }
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -307,6 +307,38 @@ pipeline {
             }
           }
         }
+        stage('Test-Signed-Package') {
+          failFast false
+          matrix {
+            agent { label 'linux && docker && ubuntu-18.04 && immutable' }
+            options { skipDefaultCheckout() }
+            axes {
+              axis {
+                name 'PHP_VERSION'
+                values '7.2', '7.3', '7.4'
+              }
+            }
+            stages {
+              stage('Release Test') {
+                steps {
+                  withGithubNotify(context: "Signed-Test-${PHP_VERSION}") {
+                    deleteDir()
+                    unstash 'source'
+                    dir("${BASE_DIR}") {
+                      unstash "${env.SIGNED_ARTIFACTS}"
+                      sh script: "PHP_VERSION=${PHP_VERSION} -C packaging install", label: 'package install'
+                    }
+                  }
+                }
+                post {
+                  always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                  }
+                }
+              }
+            }
+          }
+        }
         stage('Release CI') {
           when {
             beforeAgent true
@@ -327,9 +359,36 @@ pipeline {
             success {
               notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
             }
-            always {
-              script {
-                currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"
+          }
+        }
+        // TBD: nottify if test failures for the released packages
+        stage('Test-Released-Package') {
+          failFast false
+          matrix {
+            agent { label 'linux && docker && ubuntu-18.04 && immutable' }
+            options { skipDefaultCheckout() }
+            axes {
+              axis {
+                name 'PHP_VERSION'
+                values '7.2', '7.3', '7.4'
+              }
+            }
+            stages {
+              stage('Release Test') {
+                steps {
+                  withGithubNotify(context: "Release-Test-${PHP_VERSION}") {
+                    deleteDir()
+                    unstash 'source'
+                    dir("${BASE_DIR}"){
+                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME} -C packaging install-release", label: 'package install-release'
+                    }
+                  }
+                }
+                post {
+                  always {
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                  }
+                }
               }
             }
           }
@@ -338,6 +397,11 @@ pipeline {
       post {
         failure {
           notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release *${env.TAG_NAME}* failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+        }
+        always {
+          script {
+            currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -383,7 +383,7 @@ pipeline {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replaceAll('^v', '')} -C packaging install-release", label: 'package install-release'
+                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replaceAll('^v', '')} -C packaging install-release-github", label: 'package install-release-github'
                     }
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -380,7 +380,7 @@ pipeline {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME} -C packaging install-release", label: 'package install-release'
+                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replace('^v', '')} -C packaging install-release", label: 'package install-release'
                     }
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -327,7 +327,7 @@ pipeline {
                     unstash 'source'
                     dir("${BASE_DIR}") {
                       unstash "${env.SIGNED_ARTIFACTS}"
-                      sh script: "PHP_VERSION=${PHP_VERSION} -C packaging install", label: 'package install'
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging install", label: 'package install'
                     }
                   }
                 }
@@ -383,7 +383,7 @@ pipeline {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replaceAll('^v', '')} -C packaging install-release-github", label: 'package install-release-github'
+                      sh script: "PHP_VERSION=${PHP_VERSION} RELEASE_VERSION=${env.TAG_NAME.replaceAll('^v', '')} make -C packaging install-release-github", label: 'package install-release-github'
                     }
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -268,6 +268,7 @@ pipeline {
         SIGNED_ARTIFACTS = 'signed-artifacts'
         BUCKET_SUBFOLDER_SIGNED_ARTIFACTS = "${env.BUCKET_SUBFOLDER}/${env.SIGNED_ARTIFACTS}"
         BUCKET_SIGNED_ARTIFACTS_PATH = "gs://${env.BUCKET_NAME}/${env.BUCKET_SUBFOLDER_SIGNED_ARTIFACTS}"
+        RELEASE_URL_MESSAGE = "(<https://github.com/elastic/apm-agent-php/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
       }
       stages {
         stage('Notify') {
@@ -331,6 +332,9 @@ pipeline {
                   }
                 }
                 post {
+                  unsuccessful {
+                    notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* got some test failures in the installers.", body: "Please review the signed binaries are healthy (<${env.RUN_DISPLAY_URL}|Open>)")
+                  }
                   always {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
                   }
@@ -357,11 +361,10 @@ pipeline {
           }
           post {
             success {
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
             }
           }
         }
-        // TBD: nottify if test failures for the released packages
         stage('Test-Released-Package') {
           failFast false
           matrix {
@@ -385,6 +388,9 @@ pipeline {
                   }
                 }
                 post {
+                  unsuccessful {
+                    notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published with some test failures in the installers.", body: "Please review the signed and released binaries are healthy\nBuild: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
+                  }
                   always {
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
                   }
@@ -396,7 +402,7 @@ pipeline {
       }
       post {
         failure {
-          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release *${env.TAG_NAME}* failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release *${env.TAG_NAME}* failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
         }
         always {
           script {

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,8 +61,8 @@ make -C packaging info
 ## To test the installation in debian
 make -C packaging deb-install
 
-## To test the installation for a given release in debian
-RELEASE_VERSION=0.1 make -C packaging deb-install-release
+## To test the installation for a given release in debian using the downloaded binary
+RELEASE_VERSION=0.1 make -C packaging deb-install-release-github
 
 ## Help goal will provide further details
 make -C packaging help

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,6 +61,9 @@ make -C packaging info
 ## To test the installation in debian
 make -C packaging deb-install
 
+## To test the installation for a given release in debian
+RELEASE_VERSION=0.1 make -C packaging deb-install-release
+
 ## Help goal will provide further details
 make -C packaging help
 ```

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -6,6 +6,7 @@ PHP_AGENT_DIR:=/opt/elastic/apm-agent-php
 PHP_VERSION?=7.2
 GIT_SHA?=$(shell git rev-parse HEAD || echo "unknown")
 RELEASE_VERSION?=
+GITHUB_RELEASES_URL=https://github.com/elastic/apm-agent-php/releases/download
 
 export FPM_FLAGS=
 
@@ -129,19 +130,19 @@ install: apk-install deb-install rpm-install tar-install  ## Install all the dis
 
 .PHONY: apk-install-release
 apk-install-release: prepare-apk  ## Install the apk installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-apk
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-apk
 
 .PHONY: deb-install-release
 deb-install-release: prepare-deb  ## Install the deb installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-deb
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-deb
 
 .PHONY: rpm-install-release
 rpm-install-release: prepare-rpm  ## Install the rpm installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-rpm
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-rpm
 
 .PHONY: tar-install-release
 tar-install-release: prepare-tar  ## Install the tar installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release-tar prepare-tar
+	@docker run --rm -v $(PWD):/src -w /src -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e VERSION=$(RELEASE_VERSION) -e TYPE=release-tar prepare-tar
 
 .PHONY: install-release
 install-release: apk-install-release deb-install-release rpm-install-release tar-install-release  ## Install all the distributions for a given release

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -128,21 +128,21 @@ rpm-install: prepare-rpm  ## Install the rpm installer to run some smoke tests
 .PHONY: install
 install: apk-install deb-install rpm-install tar-install  ## Install all the distributions
 
-.PHONY: apk-install-release
-apk-install-release: prepare-apk  ## Install the apk installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-apk
+.PHONY: apk-install-release-github
+apk-install-release-github: prepare-apk  ## Install the apk installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release-github prepare-apk
 
-.PHONY: deb-install-release
-deb-install-release: prepare-deb  ## Install the deb installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-deb
+.PHONY: deb-install-release-github
+deb-install-release-github: prepare-deb  ## Install the deb installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release-github prepare-deb
 
-.PHONY: rpm-install-release
-rpm-install-release: prepare-rpm  ## Install the rpm installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release prepare-rpm
+.PHONY: rpm-install-release-github
+rpm-install-release-github: prepare-rpm  ## Install the rpm installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e TYPE=release-github prepare-rpm
 
-.PHONY: tar-install-release
-tar-install-release: prepare-tar  ## Install the tar installer from a given release to run some smoke tests
-	@docker run --rm -v $(PWD):/src -w /src -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e VERSION=$(RELEASE_VERSION) -e TYPE=release-tar prepare-tar
+.PHONY: tar-install-release-github
+tar-install-release-github: prepare-tar  ## Install the tar installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e GITHUB_RELEASES_URL=$(GITHUB_RELEASES_URL) -e VERSION=$(RELEASE_VERSION) -e TYPE=release-tar-github prepare-tar
 
-.PHONY: install-release
-install-release: apk-install-release deb-install-release rpm-install-release tar-install-release  ## Install all the distributions for a given release
+.PHONY: install-release-github
+install-release-github: apk-install-release-github deb-install-release-github rpm-install-release-github tar-install-release-github  ## Install all the distributions for a given release using the downloaded binaries

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -44,7 +44,6 @@ deb: create-deb  ## Create the deb installer
 
 .PHONY: rpm
 rpm: create-rpm  ## Create the rpm installer
-	## TODO: fpm replaces - with _ in the version
 
 .PHONY: tar
 tar: create-tar  ## Create the tar.gz

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -5,6 +5,7 @@ OUTPUT:=build/packages
 PHP_AGENT_DIR:=/opt/elastic/apm-agent-php
 PHP_VERSION?=7.2
 GIT_SHA?=$(shell git rev-parse HEAD || echo "unknown")
+RELEASE_VERSION?=
 
 export FPM_FLAGS=
 
@@ -84,33 +85,64 @@ tar-info:  ## Show the tar package metadata
 	BINARY=$$(ls -1 $(OUTPUT)/*.tar) ;\
 	docker run --rm -v $(PWD):/app -w /app --entrypoint /usr/bin/tar $(IMAGE) -tvf $$BINARY
 
-.PHONY: apk-install
-apk-install:  ## Install the apk installer to run some smoke tests
+.PHONY: prepare-apk
+prepare-apk:  ## Build the docker image for the apk smoke tests
 	@cd $(PWD)/packaging/test/alpine ;\
 	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t $@ . ;\
 	cd -
-	docker run --rm -v $(PWD):/src -w /src $@
 
-.PHONY: deb-install
-deb-install:  ## Install the deb installer to run some smoke tests
+.PHONY: prepare-deeb
+prepare-deb:  ## Build the docker image for the deb smoke tests
 	@cd $(PWD)/packaging/test/ubuntu ;\
 	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t $@ . ;\
 	cd -
-	@docker run --rm -v $(PWD):/src -w /src -e TYPE=deb $@
 
-.PHONY: tar-install
-tar-install:  ## Install the tar installer to run some smoke tests
+.PHONY: prepare-tar
+prepare-tar:  ## Build the docker image for the tar smoke tests
 	@cd $(PWD)/packaging/test/ubuntu ;\
 	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t $@ . ;\
 	cd -
-	@docker run --rm -v $(PWD):/src -w /src -e TYPE=tar $@
 
-.PHONY: rpm-install
-rpm-install:  ## Install the rpm installer to run some smoke tests
+.PHONY: prepare-rpm
+prepare-rpm:  ## Build the docker image for the rpm smoke tests
 	@cd $(PWD)/packaging/test/centos ;\
 	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t $@ . ;\
 	cd -
-	@docker run --rm -v $(PWD):/src -w /src -e TYPE=rpm $@
+
+.PHONY: apk-install
+apk-install: prepare-apk  ## Install the apk installer to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src prepare-apk
+
+.PHONY: deb-install
+deb-install: prepare-deb  ## Install the deb installer to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e TYPE=deb prepare-deb
+
+.PHONY: tar-install
+tar-install: prepare-tar  ## Install the tar installer to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e TYPE=tar prepare-tar
+
+.PHONY: rpm-install
+rpm-install: prepare-rpm  ## Install the rpm installer to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e TYPE=rpm prepare-rpm
 
 .PHONY: install
 install: apk-install deb-install rpm-install tar-install  ## Install all the distributions
+
+.PHONY: apk-install-release
+apk-install-release: prepare-apk  ## Install the apk installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-apk
+
+.PHONY: deb-install-release
+deb-install-release: prepare-deb  ## Install the deb installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-deb
+
+.PHONY: rpm-install-release
+rpm-install-release: prepare-rpm  ## Install the rpm installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release prepare-rpm
+
+.PHONY: tar-install-release
+tar-install-release: prepare-tar  ## Install the tar installer from a given release to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e VERSION=$(RELEASE_VERSION) -e TYPE=release-tar prepare-tar
+
+.PHONY: install-release
+install-release: apk-install-release deb-install-release rpm-install-release tar-install-release  ## Install all the distributions for a given release

--- a/packaging/test/alpine/Dockerfile
+++ b/packaging/test/alpine/Dockerfile
@@ -6,8 +6,10 @@ RUN apk update \
     bash \
     curl \
     git \
+    perl-utils \
     procps \
-    unzip
+    unzip \
+    wget
 
 RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/baecae060ee7602a9908f2259f7460b737839972/web/installer', 'composer-setup.php');" \
  && php -r "if (hash_file('sha384', 'composer-setup.php') === '572cb359b56ad9ae52f9c23d29d4b19a040af10d6635642e646a7caa7b96de717ce683bd797a92ce99e5929cc51e7d5f') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \

--- a/packaging/test/alpine/Dockerfile
+++ b/packaging/test/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/bae
 
 RUN php -v
 
+ENV VERSION=
+ENV GITHUB_RELEASES_URL=
 COPY entrypoint.sh /bin
 WORKDIR /src
 

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -3,8 +3,8 @@ set -x
 
 if [ "${TYPE}" = "release" ] ; then
     PACKAGE=apm-agent-php_${VERSION}_all.apk
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     apk add --allow-untrusted --verbose --no-cache "${PACKAGE}"
 else

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -10,7 +10,7 @@ BUILD_RELEASES_FOLDER=build/releases
 #### MAIN ####
 ##############
 if [ "${TYPE}" = "release-github" ] ; then
-    mkdir -p build/releases
+    mkdir -p "${BUILD_RELEASES_FOLDER}"
     PACKAGE=apm-agent-php_${VERSION}_all.apk
     wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "${BUILD_RELEASES_FOLDER}/${PACKAGE}"
     wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "${BUILD_RELEASES_FOLDER}/${PACKAGE}.sha512"

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -2,7 +2,7 @@
 set -x
 
 if [ "${TYPE}" = "release" ] ; then
-    PACKAGE=apm-agent-php_${VERSION}-preview_all.apk
+    PACKAGE=apm-agent-php_${VERSION}_all.apk
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -3,8 +3,8 @@ set -x
 
 if [ "${TYPE}" = "release-github" ] ; then
     PACKAGE=apm-agent-php_${VERSION}_all.apk
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     apk add --allow-untrusted --verbose --no-cache "${PACKAGE}"
 else

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env sh
 set -x
 
+###################
+#### VARIABLES ####
+###################
+BUILD_RELEASES_FOLDER=build/releases
+
+##############
+#### MAIN ####
+##############
 if [ "${TYPE}" = "release-github" ] ; then
     mkdir -p build/releases
     PACKAGE=apm-agent-php_${VERSION}_all.apk
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}.sha512"
-    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
-    apk add --allow-untrusted --verbose --no-cache "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "${BUILD_RELEASES_FOLDER}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "${BUILD_RELEASES_FOLDER}/${PACKAGE}.sha512"
+    cd ${BUILD_RELEASES_FOLDER} || exit
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    cd - || exit
+    apk add --allow-untrusted --verbose --no-cache "${BUILD_RELEASES_FOLDER}/${PACKAGE}"
 else
     ## Install apk package and configure the agent accordingly
     apk add --allow-untrusted --verbose --no-cache build/packages/*.apk

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -x
 
-if [ "${TYPE}" = "release" ] ; then
+if [ "${TYPE}" = "release-github" ] ; then
     PACKAGE=apm-agent-php_${VERSION}_all.apk
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -2,11 +2,12 @@
 set -x
 
 if [ "${TYPE}" = "release-github" ] ; then
+    mkdir -p build/releases
     PACKAGE=apm-agent-php_${VERSION}_all.apk
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
-    shasum -a 512 -c "${PACKAGE}.sha512"
-    apk add --allow-untrusted --verbose --no-cache "${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}.sha512"
+    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
+    apk add --allow-untrusted --verbose --no-cache "build/releases/${PACKAGE}"
 else
     ## Install apk package and configure the agent accordingly
     apk add --allow-untrusted --verbose --no-cache build/packages/*.apk

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env sh
 set -x
 
-## Install apk package and configure the agent accordingly
-apk add --allow-untrusted --verbose --no-cache build/packages/*.apk
+if [ "${TYPE}" = "release" ] ; then
+    PACKAGE=apm-agent-php_${VERSION}-preview_all.apk
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    apk add --allow-untrusted --verbose --no-cache "${PACKAGE}"
+else
+    ## Install apk package and configure the agent accordingly
+    apk add --allow-untrusted --verbose --no-cache build/packages/*.apk
+fi
 
 ## Verify if the elastic php agent is enabled
 if ! php -m | grep -q 'elastic' ; then

--- a/packaging/test/centos/Dockerfile
+++ b/packaging/test/centos/Dockerfile
@@ -12,7 +12,7 @@ RUN export PHP_VERSION_TRANSFORMED=$(echo "${PHP_VERSION}" | sed 's#\.##g') \
 ## sh: git: command not found
 # the zip extension and unzip command are both missing, skipping.
 RUN yum update -y \
-    && yum install -y git unzip \
+    && yum install -y git perl-Digest-SHA unzip wget \
     && yum clean all
 
 RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/baecae060ee7602a9908f2259f7460b737839972/web/installer', 'composer-setup.php');" \

--- a/packaging/test/centos/Dockerfile
+++ b/packaging/test/centos/Dockerfile
@@ -12,7 +12,7 @@ RUN export PHP_VERSION_TRANSFORMED=$(echo "${PHP_VERSION}" | sed 's#\.##g') \
 ## sh: git: command not found
 # the zip extension and unzip command are both missing, skipping.
 RUN yum update -y \
-    && yum install -y git perl-Digest-SHA unzip wget \
+    && yum install -y git gnupg2 perl-Digest-SHA unzip wget \
     && yum clean all
 
 RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/baecae060ee7602a9908f2259f7460b737839972/web/installer', 'composer-setup.php');" \

--- a/packaging/test/centos/Dockerfile
+++ b/packaging/test/centos/Dockerfile
@@ -22,6 +22,8 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/bae
 
 # To support tar and rpm packages
 ENV TYPE=rpm
+ENV VERSION=
+ENV GITHUB_RELEASES_URL=
 COPY entrypoint.sh /bin
 WORKDIR /src
 

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -8,14 +8,14 @@ elif [ "${TYPE}" == "release-github" ] ; then
     ## fpm replaces - with _ in the version for rpms.
     PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
     rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     rpm -ivh "${PACKAGE}"
 elif [ "${TYPE}" == "release-tar-github" ] ; then
     PACKAGE=apm-agent-php.tar
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
     tar -xf ${PACKAGE} -C /

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -9,16 +9,19 @@ BUILD_RELEASES_FOLDER=build/releases
 ###################
 #### FUNCTIONS ####
 ###################
-function downloadWithShasumValidation() {
+function download() {
     package=$1
     folder=$2
     url=$3
     mkdir -p "${folder}"
-    rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch -O "${folder}/GPG-KEY-elasticsearch"
     wget -q "${url}/${package}" -O "${folder}/${package}"
     wget -q "${url}/${package}.sha512" -O "${folder}/${package}.sha512"
-    cd ${folder} || exit
+    wget -q "${url}/${package}.asc" -O "${folder}/${package}.asc"
+    cd "${folder}" || exit
+    gpg --import "GPG-KEY-elasticsearch"
     shasum -a 512 -c "${package}.sha512"
+    gpg --verify "${package}.asc" "${package}"
     cd -
 }
 
@@ -31,11 +34,11 @@ if [ "${TYPE}" == "rpm" ] ; then
 elif [ "${TYPE}" == "release-github" ] ; then
     ## fpm replaces - with _ in the version for rpms.
     PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
-    downloadWithShasumValidation "${PACKAGE}" "${BUILD_RELEASES_FOLDER}" "${GITHUB_RELEASES_URL}/v${VERSION}"
+    download "${PACKAGE}" "${BUILD_RELEASES_FOLDER}" "${GITHUB_RELEASES_URL}/v${VERSION}"
     rpm -ivh "${BUILD_RELEASES_FOLDER}/${PACKAGE}"
 elif [ "${TYPE}" == "release-tar-github" ] ; then
     PACKAGE=apm-agent-php.tar
-    downloadWithShasumValidation "${PACKAGE}" "${BUILD_RELEASES_FOLDER}" "${GITHUB_RELEASES_URL}/v${VERSION}"
+    download "${PACKAGE}" "${BUILD_RELEASES_FOLDER}" "${GITHUB_RELEASES_URL}/v${VERSION}"
     ## Install tar package and configure the agent accordingly
     tar -xf ${BUILD_RELEASES_FOLDER}/${PACKAGE} -C /
     # shellcheck disable=SC1091

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -4,6 +4,22 @@ set -xe
 if [ "${TYPE}" == "rpm" ] ; then
     ## Install rpm package and configure the agent accordingly
     rpm -ivh build/packages/*.rpm
+elif [ "${TYPE}" == "release" ] ; then
+    PACKAGE=apm-agent-php-${VERSION}_preview-1.noarch.rpm
+    rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    rpm -ivh "${PACKAGE}"
+elif [ "${TYPE}" == "release-tar" ] ; then
+    PACKAGE=apm-agent-php.tar
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    ## Install tar package and configure the agent accordingly
+    tar -xf ${PACKAGE} -C /
+    # shellcheck disable=SC1091
+    source /.scripts/after_install
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -8,14 +8,14 @@ elif [ "${TYPE}" == "release" ] ; then
     ## fpm replaces - with _ in the version for rpms.
     PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
     rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     rpm -ivh "${PACKAGE}"
 elif [ "${TYPE}" == "release-tar" ] ; then
     PACKAGE=apm-agent-php.tar
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
     tar -xf ${PACKAGE} -C /

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -5,20 +5,22 @@ if [ "${TYPE}" == "rpm" ] ; then
     ## Install rpm package and configure the agent accordingly
     rpm -ivh build/packages/*.rpm
 elif [ "${TYPE}" == "release-github" ] ; then
+    mkdir -p build/releases
     ## fpm replaces - with _ in the version for rpms.
     PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
     rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
-    shasum -a 512 -c "${PACKAGE}.sha512"
-    rpm -ivh "${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}"
+    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
+    rpm -ivh "build/releases/${PACKAGE}"
 elif [ "${TYPE}" == "release-tar-github" ] ; then
+    mkdir -p build/releases
     PACKAGE=apm-agent-php.tar
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
-    shasum -a 512 -c "${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}"
+    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
-    tar -xf ${PACKAGE} -C /
+    tar -xf build/releases/${PACKAGE} -C /
     # shellcheck disable=SC1091
     source /.scripts/after_install
 else

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -4,7 +4,7 @@ set -xe
 if [ "${TYPE}" == "rpm" ] ; then
     ## Install rpm package and configure the agent accordingly
     rpm -ivh build/packages/*.rpm
-elif [ "${TYPE}" == "release" ] ; then
+elif [ "${TYPE}" == "release-github" ] ; then
     ## fpm replaces - with _ in the version for rpms.
     PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
     rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
@@ -12,7 +12,7 @@ elif [ "${TYPE}" == "release" ] ; then
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     rpm -ivh "${PACKAGE}"
-elif [ "${TYPE}" == "release-tar" ] ; then
+elif [ "${TYPE}" == "release-tar-github" ] ; then
     PACKAGE=apm-agent-php.tar
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -5,7 +5,8 @@ if [ "${TYPE}" == "rpm" ] ; then
     ## Install rpm package and configure the agent accordingly
     rpm -ivh build/packages/*.rpm
 elif [ "${TYPE}" == "release" ] ; then
-    PACKAGE=apm-agent-php-${VERSION}_preview-1.noarch.rpm
+    ## fpm replaces - with _ in the version for rpms.
+    PACKAGE=apm-agent-php-${VERSION/-/_}-1.noarch.rpm
     rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update \
 
 ENV TYPE=deb
 ENV VERSION=
+ENV GITHUB_RELEASES_URL=
 COPY entrypoint.sh /bin
 WORKDIR /src
 

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -10,10 +10,11 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/bae
 # sh: 1: git: not found
 # the zip extension and unzip command are both missing, skipping.
 RUN apt-get -qq update \
- && apt-get -qq install -y git procps zlib1g-dev libzip-dev unzip --no-install-recommends \
+ && apt-get -qq install -y gnupg gnupg2 git procps zlib1g-dev libzip-dev wget unzip --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 ENV TYPE=deb
+ENV VERSION=
 COPY entrypoint.sh /bin
 WORKDIR /src
 

--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/bae
 # sh: 1: git: not found
 # the zip extension and unzip command are both missing, skipping.
 RUN apt-get -qq update \
- && apt-get -qq install -y gnupg gnupg2 git procps zlib1g-dev libzip-dev wget unzip --no-install-recommends \
+ && apt-get -qq install -y dpkg-sig gnupg gnupg2 git procps zlib1g-dev libzip-dev wget unzip --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 ENV TYPE=deb

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -4,7 +4,7 @@ set -xe
 if [ "${TYPE}" == "deb" ] ; then
     ## Install debian package and configure the agent accordingly
     dpkg -i build/packages/*.deb
-elif [ "${TYPE}" == "release" ] ; then
+elif [ "${TYPE}" == "release-github" ] ; then
     PACKAGE=apm-agent-php_${VERSION}_all.deb
     wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
     apt-key add GPG-KEY-elasticsearch
@@ -14,7 +14,7 @@ elif [ "${TYPE}" == "release" ] ; then
     shasum -a 512 -c "${PACKAGE}.sha512"
     dpkg-sig --verify "${PACKAGE}"
     dpkg -i "${PACKAGE}"
-elif [ "${TYPE}" == "release-tar" ] ; then
+elif [ "${TYPE}" == "release-tar-github" ] ; then
     PACKAGE=apm-agent-php.tar
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
     wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -9,15 +9,15 @@ elif [ "${TYPE}" == "release-github" ] ; then
     wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
     apt-key add GPG-KEY-elasticsearch
     gpg --import GPG-KEY-elasticsearch
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     dpkg-sig --verify "${PACKAGE}"
     dpkg -i "${PACKAGE}"
 elif [ "${TYPE}" == "release-tar-github" ] ; then
     PACKAGE=apm-agent-php.tar
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
     tar -xf ${PACKAGE} -C /

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${TYPE}" == "deb" ] ; then
     ## Install debian package and configure the agent accordingly
     dpkg -i build/packages/*.deb
 elif [ "${TYPE}" == "release" ] ; then
-    PACKAGE=apm-agent-php_${VERSION}-preview_all.deb
+    PACKAGE=apm-agent-php_${VERSION}_all.deb
     wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
     apt-key add GPG-KEY-elasticsearch
     gpg --import GPG-KEY-elasticsearch

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -9,15 +9,15 @@ elif [ "${TYPE}" == "release" ] ; then
     wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
     apt-key add GPG-KEY-elasticsearch
     gpg --import GPG-KEY-elasticsearch
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     dpkg-sig --verify "${PACKAGE}"
     dpkg -i "${PACKAGE}"
 elif [ "${TYPE}" == "release-tar" ] ; then
     PACKAGE=apm-agent-php.tar
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
-    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}"
+    wget -q "${GITHUB_RELEASE_URL}/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
     tar -xf ${PACKAGE} -C /

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -6,10 +6,13 @@ if [ "${TYPE}" == "deb" ] ; then
     dpkg -i build/packages/*.deb
 elif [ "${TYPE}" == "release" ] ; then
     PACKAGE=apm-agent-php_${VERSION}-preview_all.deb
-    wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+    wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    apt-key add GPG-KEY-elasticsearch
+    gpg --import GPG-KEY-elasticsearch
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
     wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
     shasum -a 512 -c "${PACKAGE}.sha512"
+    dpkg-sig --verify "${PACKAGE}"
     dpkg -i "${PACKAGE}"
 elif [ "${TYPE}" == "release-tar" ] ; then
     PACKAGE=apm-agent-php.tar

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -5,22 +5,24 @@ if [ "${TYPE}" == "deb" ] ; then
     ## Install debian package and configure the agent accordingly
     dpkg -i build/packages/*.deb
 elif [ "${TYPE}" == "release-github" ] ; then
+    mkdir -p build/releases
     PACKAGE=apm-agent-php_${VERSION}_all.deb
     wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch
     apt-key add GPG-KEY-elasticsearch
     gpg --import GPG-KEY-elasticsearch
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
-    shasum -a 512 -c "${PACKAGE}.sha512"
-    dpkg-sig --verify "${PACKAGE}"
-    dpkg -i "${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}.sha512"
+    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
+    dpkg-sig --verify "build/releases/${PACKAGE}"
+    dpkg -i "build/releases/${PACKAGE}"
 elif [ "${TYPE}" == "release-tar-github" ] ; then
+    mkdir -p build/releases
     PACKAGE=apm-agent-php.tar
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}"
-    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512"
-    shasum -a 512 -c "${PACKAGE}.sha512"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}" -O "build/releases/${PACKAGE}"
+    wget -q "${GITHUB_RELEASES_URL}/v${VERSION}/${PACKAGE}.sha512" -O "build/releases/${PACKAGE}.sha512"
+    shasum -a 512 -c "build/releases/${PACKAGE}.sha512"
     ## Install tar package and configure the agent accordingly
-    tar -xf ${PACKAGE} -C /
+    tar -xf build/releases/${PACKAGE} -C /
     # shellcheck disable=SC1091
     source /.scripts/after_install
 else

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -4,6 +4,22 @@ set -xe
 if [ "${TYPE}" == "deb" ] ; then
     ## Install debian package and configure the agent accordingly
     dpkg -i build/packages/*.deb
+elif [ "${TYPE}" == "release" ] ; then
+    PACKAGE=apm-agent-php_${VERSION}-preview_all.deb
+    wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    dpkg -i "${PACKAGE}"
+elif [ "${TYPE}" == "release-tar" ] ; then
+    PACKAGE=apm-agent-php.tar
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}"
+    wget -q "https://github.com/elastic/apm-agent-php/releases/download/v${VERSION}/${PACKAGE}.sha512"
+    shasum -a 512 -c "${PACKAGE}.sha512"
+    ## Install tar package and configure the agent accordingly
+    tar -xf ${PACKAGE} -C /
+    # shellcheck disable=SC1091
+    source /.scripts/after_install
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /


### PR DESCRIPTION
### What

Since internal-ci is in charge to generate the signed artifacts and publish them to github, this PR verifies any binaries manipulation get tested `before` and `after` the release.

Reports the release status if test failures.

Verify signed binaries (deb, rpm and tar) with their asc files as stated in [here](https://serverfault.com/a/896232).

### Why

Detect any corruptions in the binaries and validates the installation process similar to what our users will run.

### Issues

Closes https://github.com/elastic/apm-agent-php/issues/191 and https://github.com/elastic/apm-agent-php/issues/190

### How to test this


```bash
$ RELEASE_VERSION=0.1 make -C packaging install-release-github
...
OK (19 tests, 600 assertions)
> @putenv ELASTIC_APM_TESTS_APP_CODE_HOST_KIND=CLI_builtin_HTTP_server
> composer run-script run_component_tests_configured
> phpunit -c phpunit_component_tests.xml
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.33
Configuration: /src/phpunit_component_tests.xml

...................                                               19 / 19 (100%)

Time: 41.58 seconds, Memory: 14.00 MB

$ PHP_VERSIO=7.4 RELEASE_VERSION=0.1 make -C packaging install-release
```

## What kind of gpg validations?

### DEB

```
+ BUILD_RELEASES_FOLDER=build/releases
+ '[' release-github == deb ']'
+ '[' release-github == release-github ']'
+ PACKAGE=apm-agent-php_0.1-preview_all.deb
+ downloadWithShasumValidation apm-agent-php_0.1-preview_all.deb build/releases https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ package=apm-agent-php_0.1-preview_all.deb
+ folder=build/releases
+ url=https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ mkdir -p build/releases
+ wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch -O build/releases/GPG-KEY-elasticsearch
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php_0.1-preview_all.deb -O build/releases/apm-agent-php_0.1-preview_all.deb
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php_0.1-preview_all.deb.sha512 -O build/releases/apm-agent-php_0.1-preview_all.deb.sha512
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php_0.1-preview_all.deb.asc -O build/releases/apm-agent-php_0.1-preview_all.deb.asc
+ cd build/releases
+ gpg --import GPG-KEY-elasticsearch
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key D27D666CD88E42B4: public key "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
+ shasum -a 512 -c apm-agent-php_0.1-preview_all.deb.sha512
apm-agent-php_0.1-preview_all.deb: OK
+ gpg --verify apm-agent-php_0.1-preview_all.deb.asc apm-agent-php_0.1-preview_all.deb
gpg: Signature made Tue Sep 29 16:34:10 2020 UTC
gpg:                using RSA key 46095ACC8548582C1A2699A9D27D666CD88E42B4
gpg: Good signature from "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 4609 5ACC 8548 582C 1A26  99A9 D27D 666C D88E 42B4
+ cd -
/src
+ dpkg-sig --verify build/releases/apm-agent-php_0.1-preview_all.deb
Processing build/releases/apm-agent-php_0.1-preview_all.deb...
GOODSIG _gpgelastic 46095ACC8548582C1A2699A9D27D666CD88E42B4 1601397249
+ dpkg -i build/releases/apm-agent-php_0.1-preview_all.deb
```


### RPM

```
+ BUILD_RELEASES_FOLDER=build/releases
+ '[' release-github == rpm ']'
+ '[' release-github == release-github ']'
+ PACKAGE=apm-agent-php-0.1_preview-1.noarch.rpm
+ download apm-agent-php-0.1_preview-1.noarch.rpm build/releases https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ package=apm-agent-php-0.1_preview-1.noarch.rpm
+ folder=build/releases
+ url=https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ mkdir -p build/releases
+ wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch -O build/releases/GPG-KEY-elasticsearch
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php-0.1_preview-1.noarch.rpm -O build/releases/apm-agent-php-0.1_preview-1.noarch.rpm
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php-0.1_preview-1.noarch.rpm.sha512 -O build/releases/apm-agent-php-0.1_preview-1.noarch.rpm.sha512
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php-0.1_preview-1.noarch.rpm.asc -O build/releases/apm-agent-php-0.1_preview-1.noarch.rpm.asc
+ cd build/releases
+ gpg --import GPG-KEY-elasticsearch
gpg: directory `/root/.gnupg' created
gpg: new configuration file `/root/.gnupg/gpg.conf' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg' created
gpg: keyring `/root/.gnupg/pubring.gpg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key D88E42B4: public key "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
+ shasum -a 512 -c apm-agent-php-0.1_preview-1.noarch.rpm.sha512
apm-agent-php-0.1_preview-1.noarch.rpm: OK
+ gpg --verify apm-agent-php-0.1_preview-1.noarch.rpm.asc apm-agent-php-0.1_preview-1.noarch.rpm
gpg: Signature made Tue Sep 29 16:34:08 2020 UTC using RSA key ID D88E42B4
gpg: Good signature from "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 4609 5ACC 8548 582C 1A26  99A9 D27D 666C D88E 42B4
+ cd -
/src
+ rpm -ivh build/releases/apm-agent-php-0.1_preview-1.noarch.rpm
warning: build/releases/apm-agent-php-0.1_preview-1.noarch.rpm: Header V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
```


### TAR

```
+ BUILD_RELEASES_FOLDER=build/releases
+ '[' release-tar-github == rpm ']'
+ '[' release-tar-github == release-github ']'
+ '[' release-tar-github == release-tar-github ']'
+ PACKAGE=apm-agent-php.tar
+ download apm-agent-php.tar build/releases https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ package=apm-agent-php.tar
+ folder=build/releases
+ url=https://github.com/elastic/apm-agent-php/releases/download/v0.1
+ mkdir -p build/releases
+ wget -q https://artifacts.elastic.co/GPG-KEY-elasticsearch -O build/releases/GPG-KEY-elasticsearch
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php.tar -O build/releases/apm-agent-php.tar
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php.tar.sha512 -O build/releases/apm-agent-php.tar.sha512
+ wget -q https://github.com/elastic/apm-agent-php/releases/download/v0.1/apm-agent-php.tar.asc -O build/releases/apm-agent-php.tar.asc
+ cd build/releases
+ gpg --import GPG-KEY-elasticsearch
gpg: directory `/root/.gnupg' created
gpg: new configuration file `/root/.gnupg/gpg.conf' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg' created
gpg: keyring `/root/.gnupg/pubring.gpg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key D88E42B4: public key "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
+ shasum -a 512 -c apm-agent-php.tar.sha512
apm-agent-php.tar: OK
+ gpg --verify apm-agent-php.tar.asc apm-agent-php.tar
gpg: Signature made Tue Sep 29 16:34:08 2020 UTC using RSA key ID D88E42B4
gpg: Good signature from "Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 4609 5ACC 8548 582C 1A26  99A9 D27D 666C D88E 42B4
+ cd -
/src
+ tar -xf build/releases/apm-agent-php.tar -C /
+ source /.scripts/after_install


```