### PR TITLE
[DOCS] Automate changelog generation

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -63,6 +63,21 @@ composer: prepare  ## Run composer
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
 		sh -c '/app/.ci/composer.sh'
 
+.PHONY: changelog
+changelog:  ## Generate the changelog
+ifndef GITHUB_TOKEN
+	@echo "Please set GITHUB_TOKEN in the environment to perform a release"
+	exit 1
+endif
+ifndef PREVIOUS_TAG_NAME
+	@echo "Please set PREVIOUS_TAG_NAME in the environment to perform a release"
+	exit 1
+endif
+	@docker run -t --rm \
+		-v "$(PWD)":/usr/local/src \
+		-w /usr/local/src \
+		ferrarimarco/github-changelog-generator --token ${GITHUB_TOKEN} --since-tag ${PREVIOUS_TAG_NAME}
+
 .PHONY: release
 release:  ## Run a release given the GITHUB_TOKEN and TAG_NAME
 ifndef GITHUB_TOKEN

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,6 @@
+unreleased=true
+project=apm-agent-php
+user=elastic
+issues=false
+pr-wo-labels=false
+author=false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,6 +28,9 @@ GITHUB_TOKEN=**** TAG_NAME=v1.0.0 make -f .ci/Makefile release
 ## To generate the agent extension with the existing PHP API for alpine
 PHP_VERSION=7.2 DOCKERFILE=Dockerfile.alpine make -f .ci/Makefile generate-for-package
 
+## To create a changelog
+make -f .ci/Makefile changelog
+
 ## Help goal will provide further details
 make -f .ci/Makefile help
 ```


### PR DESCRIPTION
### What

Uses https://github.com/github-changelog-generator/github-changelog-generator to generate the changelog.

It uses the env variable PREVIOUS_TAG_NAME and GITHUB_TOKEN to interact with GitHub and filter the changes to be shown.

### Why

Let's work in the automation fo the changelog generation.

### Notes

I cannot find a tool to format the CHANGELOG.md to the CHANGELOG.asciidoc format. So most likely we will need to create it ourselves.
