### PR TITLE
[CI][RELEASE] notify when a tag release is created

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -443,9 +443,3 @@ def notifyStatus(def args = [:]) {
   def bodyEmail = args.body.replaceAll('\\(<', '').replaceAll('\\|.*>\\)', '')
   emailext(subject: args.subject, to: "${env.NOTIFY_TO}", body: bodyEmail)
 }
-
-// TODO: to be added to the shared library
-def isTag() {
-  def ret = env.TAG_NAME?.trim() ? true : false
-  return ret
-}

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,6 +32,9 @@ pipeline {
       stages {
         stage('Checkout') {
           steps {
+            whenTrue(isInternalCI() && isTag()) {
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+            }
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
@@ -439,4 +442,10 @@ def notifyStatus(def args = [:]) {
   // transform slack URL format '(<URL|description>)' to 'URL'.
   def bodyEmail = args.body.replaceAll('\\(<', '').replaceAll('\\|.*>\\)', '')
   emailext(subject: args.subject, to: "${env.NOTIFY_TO}", body: bodyEmail)
+}
+
+// TODO: to be added to the shared library
+def isTag() {
+  def ret = env.TAG_NAME?.trim() ? true : false
+  return ret
 }


### PR DESCRIPTION
## What

Add more visibility regarding the release automation. This notification will only happen when a tag release is created and it's running in the `internal-ci`.

## Issues

Depends on https://github.com/elastic/apm-pipeline-library/pull/749