### PR TITLE
ci(jenkins): trigger async ITs and update github check for the pull request

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -286,8 +286,8 @@ pipeline {
           steps {
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             build(job: env.ITS_PIPELINE, propagate: false, wait: true,
-                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'Php'),
-                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO} --opbeans-php-agent-branch ${env.GIT_BASE_COMMIT}"),
+                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
+                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
                                 string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                 string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                 string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             build(job: env.ITS_PIPELINE, propagate: false, wait: true,
                   parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
-                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic/' + env.REPO}"),
                                 string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                 string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                 string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -154,6 +154,22 @@ pipeline {
             }
           }
         }
+        stage('Integration Tests') {
+          agent none
+          when {
+            beforeAgent true
+            changeRequest()
+          }
+          steps {
+            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+            build(job: env.ITS_PIPELINE, propagate: false, wait: true,
+                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
+                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
+                                string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])
+          }
+        }
         stage('Package Generation') {
           when {
             beforeAgent true
@@ -275,22 +291,6 @@ pipeline {
                 echo 'STORE docker logs'
               }
             }
-          }
-        }
-        stage('Integration Tests') {
-          agent none
-          when {
-            beforeAgent true
-            changeRequest()
-          }
-          steps {
-            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-            build(job: env.ITS_PIPELINE, propagate: false, wait: true,
-                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
-                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO}"),
-                                string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                   parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
-                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic/' + env.REPO}"),
+                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT}"),
                                 string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                 string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                 string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,8 @@ pipeline {
     SLACK_CHANNEL = '#apm-agent-php'
     NOTIFY_TO = 'build-apm+apm-agent-php@elastic.co'
     ONLY_DOCS = "false"
+    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
@@ -273,6 +275,22 @@ pipeline {
                 echo 'STORE docker logs'
               }
             }
+          }
+        }
+        stage('Integration Tests') {
+          agent none
+          when {
+            beforeAgent true
+            changeRequest()
+          }
+          steps {
+            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+            build(job: env.ITS_PIPELINE, propagate: false, wait: true,
+                  parameters: [ string(name: 'INTEGRATION_TEST', value: 'Php'),
+                                string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic'}/${env.REPO} --opbeans-php-agent-branch ${env.GIT_BASE_COMMIT}"),
+                                string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT) ])
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
           }
           steps {
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-            build(job: env.ITS_PIPELINE, propagate: false, wait: true,
+            build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                   parameters: [ string(name: 'INTEGRATION_TEST', value: 'PHP'),
                                 string(name: 'BUILD_OPTS', value: "--php-agent-version ${env.GIT_BASE_COMMIT} --php-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic/' + env.REPO}"),
                                 string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- It's triggered for each PR by default and disabled to any upstream branches.
- Trigger the Integration Tests, aka ITs, pipelines from https://github.com/elastic/apm-integration-testing based on PRs or on demand, aka manually.
- It does trigger only the `PHP` stage in the ITs.
- ITs should be async.
- This new stage notifies the GitHub check with the status of the execution.
- It runs immediately after the build/test stage and before the package-generation stage.

## Tasks
- [x] It does require to support ITs for PHP

## Issues

Caused by https://github.com/elastic/apm-integration-testing/pull/863 and https://github.com/elastic/apm-integration-testing/issues/865

## Tests


- Downstream -> [build](https://apm-ci.elastic.co/job/apm-integration-tests-selector-mbp/view/change-requests/job/PR-946/2/)