### PR TITLE
[CI] enable test reporting for flaky results

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -466,7 +466,8 @@ pipeline {
       // Reporting disables in the `internal-ci` since credentials are not in place
       // OTOH it avoids duplicated notifications
       whenFalse(isInternalCI()){
-        notifyBuildResult()
+        notifyBuildResult(prComment: true, analyzeFlakey: true,
+                          flakyReportIdx: 'reporter-apm-agent-php-apm-agent-php-master')
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Enable the flaky test analyser using the `master` branch as a source of truth for the time being.

## Why is it important?

This will help to automate the flaky test analyser process:
- By tracking test failures and flaky test failures.
- Raising issues for those flaky test failures with the labels: `flaky-test,ci-reported`
- Report the test flaky status as a GitHub comment.

Then contributors and reviewers will be able to understand the whole test context and whether those failures were already reported as flaky in the past.

## Issues

Consumes https://github.com/elastic/apm-pipeline-library/pull/754

## Test

- See new comment https://github.com/elastic/apm-agent-php/pull/241#issuecomment-713410908
