### PR TITLE
[CI] Add test loop pipeline

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -68,7 +68,7 @@ composer: prepare  ## Run composer
 
 .PHONY: loop
 loop:  ## Bump the version given VERSION
-	.ci/loop.sh "$(LOOPS)"
+	.ci/loop.sh "$(LOOPS)" "${DOCKERFILE}" "${PHP_VERSION}"
 
 .PHONY: previous-version
 previous-version:  ## Fetch the current version

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -3,6 +3,7 @@ SHELL=/bin/bash -o pipefail
 IMAGE := test-php
 PHP_VERSION ?= 7.2
 DOCKERFILE ?= Dockerfile
+LOOPS ?= 50
 SUFFIX := 
 ifeq ($(DOCKERFILE), Dockerfile.alpine)
     ## This is only required to tag the docker images used for building/testing this project
@@ -19,7 +20,7 @@ help: ## Display this help text
 
 .PHONY: prepare
 prepare:  ## Build docker image for building and testing the project
-	docker build \
+	@docker build \
 		--build-arg PHP_VERSION=${PHP_VERSION} \
 		--tag $(IMAGE):${PHP_VERSION}$(SUFFIX) \
 		-f ${DOCKERFILE} .
@@ -64,6 +65,10 @@ composer: prepare  ## Run composer
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
 		sh -c '/app/.ci/composer.sh'
+
+.PHONY: loop
+loop:  ## Bump the version given VERSION
+	.ci/loop.sh "$(LOOPS)"
 
 .PHONY: previous-version
 previous-version:  ## Fetch the current version

--- a/.ci/jobs/apm-agent-php-mbp.yml
+++ b/.ci/jobs/apm-agent-php-mbp.yml
@@ -3,3 +3,39 @@
     name: apm-agent-php/apm-agent-php-mbp
     display-name: APM Agent PHP
     description: APM Agent PHP
+    script-path: .ci/Jenkinsfile
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        notification-context: 'apm-ci'
+        repo: apm-agent-php
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'

--- a/.ci/jobs/loop-mbp.yml
+++ b/.ci/jobs/loop-mbp.yml
@@ -1,40 +1,27 @@
 ---
-
-##### GLOBAL METADATA
-
-- meta:
-    cluster: apm-ci
-
-##### JOB DEFAULTS
-
 - job:
-    view: APM-CI
-    project-type: multibranch
-    logrotate:
-      numToKeep: 100
-    concurrent: true
-    node: linux
-    script-path: .ci/Jenkinsfile
+    name: apm-agent-php/apm-agent-php-loop-mbp
+    display-name: Test Loop APM Agent PHP
+    description: Test Loop APM Agent PHP
+    script-path: .ci/loop.groovy
     scm:
     - github:
         branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        discover-tags: true
-        notification-context: 'apm-ci'
+        discover-tags: false
+        notification-context: 'apm-loop'
         repo: apm-agent-php
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
+        - skip-initial-build: true
         - regular-branches: true
         - change-request:
-            ignore-target-only-changes: false
+            ignore-target-only-changes: true
         clean:
           after: true
           before: true
@@ -50,8 +37,3 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1w
-    prune-dead-branches: true
-    publishers:
-    - email:
-        recipients: infra-root+build@elastic.co

--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -79,7 +79,7 @@ pipeline {
   }
   post {
     cleanup {
-      ## PR comment is not needed with this pipeline
+      // PR comment is not needed with this pipeline
       notifyBuildResult(prComment: false)
     }
   }

--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -1,0 +1,92 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && docker && ubuntu-18.04 && immutable' }
+  environment {
+    REPO = 'apm-agent-php'
+    BASE_DIR = "src/go.elastic.co/apm/${env.REPO}"
+    SLACK_CHANNEL = '#apm-agent-php'
+    NOTIFY_TO = 'build-apm+apm-agent-php@elastic.co'
+    ONLY_DOCS = "false"
+    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+    timeout(time: 3, unit: 'HOURS')
+  }
+  triggers {
+    issueCommentTrigger('(?i)/loop\\W+test')
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        whenTrue(isInternalCI() && isTag()) {
+          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+        }
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    stage('BuildAndTest') {
+      failFast false
+      matrix {
+        agent { label 'linux && docker && ubuntu-18.04 && immutable' }
+        options { skipDefaultCheckout() }
+        axes {
+          axis {
+            name 'PHP_VERSION'
+            values '7.2', '7.3', '7.4'
+          }
+          axis {
+            name 'DOCKERFILE'
+            values 'Dockerfile', 'Dockerfile.alpine'
+          }
+        }
+        stages {
+          stage('Build') {
+            steps {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                // When running in the CI with multiple parallel stages
+                // the access could be considered as a DDOS attack.
+                retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+                  sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile prepare", label: 'prepare docker image'
+                }
+                sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile build", label: 'build'
+              }
+            }
+          }
+          stage('Tests loop') {
+            steps {
+              dir("${BASE_DIR}"){
+                sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile loop", label: 'test'
+              }
+            }
+            post {
+              always {
+                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/junit.xml")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: true)
+    }
+  }
+}

--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -7,11 +7,7 @@ pipeline {
   environment {
     REPO = 'apm-agent-php'
     BASE_DIR = "src/go.elastic.co/apm/${env.REPO}"
-    SLACK_CHANNEL = '#apm-agent-php'
     NOTIFY_TO = 'build-apm+apm-agent-php@elastic.co'
-    ONLY_DOCS = "false"
-    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
@@ -21,17 +17,14 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
     quietPeriod(10)
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 5, unit: 'HOURS')
   }
   triggers {
-    issueCommentTrigger('(?i)/loop\\W+test')
+    issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?loop\\W+tests(?:\\W+please)?.*')
   }
   stages {
     stage('Checkout') {
       steps {
-        whenTrue(isInternalCI() && isTag()) {
-          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
-        }
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+LOOPS=${1:-50}
+for (( c=1; c<=LOOPS; c++ ))
+do  
+    echo "Loop $c"
+    make -f .ci/Makefile test
+    make -f .ci/Makefile composer
+done

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
 LOOPS=${1:-50}
+DOCKERFILE=${2:-Dockerfile}
+PHP_VERSION=${3:-7.2}
 for (( c=1; c<=LOOPS; c++ ))
 do  
     echo "Loop $c"
-    make -f .ci/Makefile test
-    make -f .ci/Makefile composer
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer
+
+    ## TODO: rename test report files to include the iteration name.
 done


### PR DESCRIPTION
### What

New Multibranch Pipeline to support the requirement of running the UTs/ITs for a while 

- On a PR basis with the comment that contains `Jenkins run the loop tests`
- On a merge to master

_NOTE_: the GH comment was chosen in a way it does not overlap with the existing one in the main pipeline `Jenkins run the tests`

### Why

to detect any kind of flakiness 

### Issues

Closes https://github.com/elastic/apm-agent-php/issues/243

### Tasks

- Support nightly builds in a follow up
- This PR will require a follow-up

### Tests

- Run locally

```bash
$ make -f .ci/Makefile loop
```