### PR TITLE
[CI] increase number of loops and store tests

### DIFF
--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -73,8 +73,8 @@ pipeline {
             }
             post {
               always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit*.xml,${BASE_DIR}/junit*.xml")
-                archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/*.txt')
+                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit*.xml")
+                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/*.txt")
               }
             }
           }

--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -73,8 +73,8 @@ pipeline {
             }
             post {
               always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit*.xml")
-                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/*.txt")
+                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/**/junit*.xml")
+                archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/**/*.txt")
               }
             }
           }

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -16,11 +16,12 @@ do
 
     ## Store test results with the iteration
     if [ -e $TEST_REPORT_TEST ] ; then
-        mv $TEST_REPORT_TEST "$TEST_REPORT_TEST.$c.xml"
+        mv $TEST_REPORT_TEST "${OUTPUT_FOLDER}/junit-test-$c.xml"
     fi
 
     ## Store composer test results with the iteration
     if [ -e $TEST_REPORT_COMPOSER ] ; then
-        mv $TEST_REPORT_COMPOSER "$TEST_REPORT_COMPOSER.$c.xml"
+        ## Let's copy since mv does not work when reusing the workspace for some required permissions
+        cp $TEST_REPORT_COMPOSER "${OUTPUT_FOLDER}/junit-composer-$c.xml"
     fi
 done

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -4,15 +4,17 @@ LOOPS=${1:-50}
 DOCKERFILE=${2:-Dockerfile}
 PHP_VERSION=${3:-7.2}
 
-OUTPUT_FOLDER=build
+OUTPUT_FOLDER="build/loop-$DOCKERFILE-$PHP_VERSION"
 TEST_REPORT_TEST="junit.xml"
 TEST_REPORT_COMPOSER="_GENERATED/COMPONENT_TESTS/log_as_junit.xml"
-mkdir -p $OUTPUT_FOLDER || true
+mkdir -p "${OUTPUT_FOLDER}" || true
+
 for (( c=1; c<=LOOPS; c++ ))
 do  
     echo "Loop $c"
-    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test | tee "$OUTPUT_FOLDER/$c.txt"
-    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer | tee -a "$OUTPUT_FOLDER/$c.txt"
+    OUTPUT_FILE="$OUTPUT_FOLDER/$c.txt"
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test | tee "$OUTPUT_FILE"
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer | tee -a "$OUTPUT_FILE"
 
     ## Store test results with the iteration
     if [ -e $TEST_REPORT_TEST ] ; then

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -3,11 +3,24 @@
 LOOPS=${1:-50}
 DOCKERFILE=${2:-Dockerfile}
 PHP_VERSION=${3:-7.2}
+
+OUTPUT_FOLDER=build
+TEST_REPORT_TEST="junit.xml"
+TEST_REPORT_COMPOSER="_GENERATED/COMPONENT_TESTS/log_as_junit.xml"
+mkdir -p $OUTPUT_FOLDER || true
 for (( c=1; c<=LOOPS; c++ ))
 do  
     echo "Loop $c"
-    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test
-    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test | tee "$OUTPUT_FOLDER/$c.txt"
+    PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer | tee -a "$OUTPUT_FOLDER/$c.txt"
 
-    ## TODO: rename test report files to include the iteration name.
+    ## Store test results with the iteration
+    if [ -e $TEST_REPORT_TEST ] ; then
+        mv $TEST_REPORT_TEST "$TEST_REPORT_TEST.$c.xml"
+    fi
+
+    ## Store composer test results with the iteration
+    if [ -e $TEST_REPORT_COMPOSER ] ; then
+        mv $TEST_REPORT_COMPOSER "$TEST_REPORT_COMPOSER.$c.xml"
+    fi
 done


### PR DESCRIPTION
### What

- Increase up to 2 hours approx 200 iterations
- Rename test results to simplify the reporting in the CI and also store the loop logs in a single file for helping with the debugging
- Enable UI parameter to configure the number of iterations

### Why

50 iterations takes 40 minutes and easy to debug

### Tests


![image](https://user-images.githubusercontent.com/2871786/97196371-4e42ad00-17a4-11eb-9896-e28623f7e3b1.png)

![image](https://user-images.githubusercontent.com/2871786/97196423-5b5f9c00-17a4-11eb-8f78-8252211d006f.png)