### PR TITLE
[CI] split static check with unit and component tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -113,11 +113,11 @@ pipeline {
                   }
                 }
               }
-              stage('PHPT Tests') {
+              stage('Static check and Unit Tests') {
                 steps {
-                  withGithubNotify(context: "PHPT-Tests-${PHP_VERSION}", tab: 'tests') {
+                  withGithubNotify(context: "Static-Check-Unit-Tests-${PHP_VERSION}", tab: 'tests') {
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test", label: 'test'
+                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile static-check-unit-test", label: 'static-check-unit-test'
                     }
                   }
                 }
@@ -137,11 +137,11 @@ pipeline {
                   }
                 }
               }
-              stage('PHPUnit Tests') {
+              stage('Component Tests') {
                 steps {
-                  withGithubNotify(context: "PHPUnit-Tests-${PHP_VERSION}", tab: 'tests') {
+                  withGithubNotify(context: "Component-Tests-${PHP_VERSION}", tab: 'tests') {
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer", label: 'composer'
+                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile component-test", label: 'component-test'
                     }
                   }
                 }

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -33,14 +33,14 @@ build: prepare  ## Build the project
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX)
 
-.PHONY: test
-test: prepare  ## Test the project
+.PHONY: static-check-unit-test
+static-check-unit-test: prepare  ## Test the static check and unit tests
 	# docker as the current user
 	docker run --rm -t \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
-		make test
+		/app/.ci/static-check-unit-test.sh
 
 .PHONY: generate-for-package
 generate-for-package: prepare  ## Generate the agent extension for the package
@@ -58,13 +58,13 @@ interactive: prepare  ## Run an interactive docker shell
 		$(IMAGE):${PHP_VERSION} \
 		/bin/bash
 
-.PHONY: composer
-composer: prepare  ## Run composer
+.PHONY: component-test
+component-test: prepare  ## Run component-test
 	# docker as root to install the extension
 	docker run -t --rm \
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
-		sh -c '/app/.ci/composer.sh'
+		sh -c '/app/.ci/component-test.sh'
 
 .PHONY: loop
 loop:  ## Bump the version given VERSION

--- a/.ci/component-test.sh
+++ b/.ci/component-test.sh
@@ -8,15 +8,10 @@ echo 'elastic_apm.bootstrap_php_part_file=/app/src/bootstrap_php_part.php' >> ${
 php -m
 cd /app
 
-##
-## Validate the installation works as expected with composer
-##
-
 # Install 3rd party dependencies
 composer install
 
 # Start syslog
-
 if which syslogd; then
     syslogd
 else
@@ -28,10 +23,8 @@ else
     fi
 fi
 
-
 # Run component tests
-
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
 
     if [ -f "/var/log/syslog" ]; then

--- a/.ci/static-check-unit-test.sh
+++ b/.ci/static-check-unit-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -xe
+
+## This make runs PHPT
+make test
+
+cd /app
+
+# Install 3rd party dependencies
+composer install
+
+# Run static_check_and_run_unit_tests
+composer run-script static_check_and_run_unit_tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,14 +13,14 @@ PHP_VERSION=7.2 make -f .ci/Makefile prepare
 ## To compile the library
 PHP_VERSION=7.2 make -f .ci/Makefile build
 
-## To test the library
-PHP_VERSION=7.2 make -f .ci/Makefile test
+## To run the unit test and static check
+PHP_VERSION=7.2 make -f .ci/Makefile static-check-unit-test
 
 ## To generate the agent extension with the existing PHP API
 PHP_VERSION=7.2 make -f .ci/Makefile generate-for-package
 
-## To install with composer
-PHP_VERSION=7.2 make -f .ci/Makefile composer
+## To run the component tests
+PHP_VERSION=7.2 make -f .ci/Makefile component-test
 
 ## To release given the GITHUB_TOKEN and TAG_NAME
 GITHUB_TOKEN=**** TAG_NAME=v1.0.0 make -f .ci/Makefile release

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -32,7 +32,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 syslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/messages
     exit 1

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 /usr/sbin/rsyslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/syslog
     exit 1

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 /usr/sbin/rsyslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/syslog
     exit 1


### PR DESCRIPTION
### What

Split unit tests from the component tests and add static analysis within the unit test stage

### Why

To avoid environmental issues with the agent installation that clashes with the unit tests.