### PR TITLE
Disable C-part unit tests for stack trace capture on Alpine Linux

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -113,11 +113,11 @@ pipeline {
                   }
                 }
               }
-              stage('PHPT Tests') {
+              stage('Static check and Unit Tests') {
                 steps {
-                  withGithubNotify(context: "PHPT-Tests-${PHP_VERSION}", tab: 'tests') {
+                  withGithubNotify(context: "Static-Check-Unit-Tests-${PHP_VERSION}", tab: 'tests') {
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile test", label: 'test'
+                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile static-check-unit-test", label: 'static-check-unit-test'
                     }
                   }
                 }
@@ -137,11 +137,11 @@ pipeline {
                   }
                 }
               }
-              stage('PHPUnit Tests') {
+              stage('Component Tests') {
                 steps {
-                  withGithubNotify(context: "PHPUnit-Tests-${PHP_VERSION}", tab: 'tests') {
+                  withGithubNotify(context: "Component-Tests-${PHP_VERSION}", tab: 'tests') {
                     dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile composer", label: 'composer'
+                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile component-test", label: 'component-test'
                     }
                   }
                 }

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -33,14 +33,14 @@ build: prepare  ## Build the project
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX)
 
-.PHONY: test
-test: prepare  ## Test the project
+.PHONY: static-check-unit-test
+static-check-unit-test: prepare  ## Test the static check and unit tests
 	# docker as the current user
 	docker run --rm -t \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
-		make test
+		/app/.ci/static-check-unit-test.sh
 
 .PHONY: generate-for-package
 generate-for-package: prepare  ## Generate the agent extension for the package
@@ -58,13 +58,13 @@ interactive: prepare  ## Run an interactive docker shell
 		$(IMAGE):${PHP_VERSION} \
 		/bin/bash
 
-.PHONY: composer
-composer: prepare  ## Run composer
+.PHONY: component-test
+component-test: prepare  ## Run component-test
 	# docker as root to install the extension
 	docker run -t --rm \
 		-v $(PWD):/app \
 		$(IMAGE):${PHP_VERSION}$(SUFFIX) \
-		sh -c '/app/.ci/composer.sh'
+		sh -c '/app/.ci/component-test.sh'
 
 .PHONY: loop
 loop:  ## Bump the version given VERSION

--- a/.ci/component-test.sh
+++ b/.ci/component-test.sh
@@ -8,15 +8,10 @@ echo 'elastic_apm.bootstrap_php_part_file=/app/src/bootstrap_php_part.php' >> ${
 php -m
 cd /app
 
-##
-## Validate the installation works as expected with composer
-##
-
 # Install 3rd party dependencies
 composer install
 
 # Start syslog
-
 if which syslogd; then
     syslogd
 else
@@ -28,10 +23,8 @@ else
     fi
 fi
 
-
 # Run component tests
-
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
 
     if [ -f "/var/log/syslog" ]; then

--- a/.ci/static-check-unit-test.sh
+++ b/.ci/static-check-unit-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -xe
+
+## This make runs PHPT
+make test
+
+cd /app
+
+# Install 3rd party dependencies
+composer install
+
+# Run static_check_and_run_unit_tests
+composer run-script static_check_and_run_unit_tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,14 +13,14 @@ PHP_VERSION=7.2 make -f .ci/Makefile prepare
 ## To compile the library
 PHP_VERSION=7.2 make -f .ci/Makefile build
 
-## To test the library
-PHP_VERSION=7.2 make -f .ci/Makefile test
+## To run the unit test and static check
+PHP_VERSION=7.2 make -f .ci/Makefile static-check-unit-test
 
 ## To generate the agent extension with the existing PHP API
 PHP_VERSION=7.2 make -f .ci/Makefile generate-for-package
 
-## To install with composer
-PHP_VERSION=7.2 make -f .ci/Makefile composer
+## To run the component tests
+PHP_VERSION=7.2 make -f .ci/Makefile component-test
 
 ## To release given the GITHUB_TOKEN and TAG_NAME
 GITHUB_TOKEN=**** TAG_NAME=v1.0.0 make -f .ci/Makefile release

--- a/packaging/test/alpine/entrypoint.sh
+++ b/packaging/test/alpine/entrypoint.sh
@@ -32,7 +32,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 syslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/messages
     exit 1

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 /usr/sbin/rsyslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/syslog
     exit 1

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 ## Validate the installation works as expected with composer
 composer install
 /usr/sbin/rsyslogd
-if ! composer run-script static_check_and_run_tests ; then
+if ! composer run-script run_component_tests ; then
     echo 'Something bad happened when running the tests, see the output from the syslog'
     cat /var/log/syslog
     exit 1

--- a/src/ext/unit_tests/platform_tests.c
+++ b/src/ext/unit_tests/platform_tests.c
@@ -64,6 +64,15 @@ void stream_errno_overflow( void** testFixtureState )
     testStreamXyzOverflow( streamErrNoUnderTest );
 }
 
+#ifndef ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01
+#   ifdef ELASTIC_APM_PLATFORM_HAS_BACKTRACE
+#       define ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 1
+#   else // #ifdef ELASTIC_APM_PLATFORM_HAS_BACKTRACE
+#       define ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 0
+#   endif // #ifdef ELASTIC_APM_PLATFORM_HAS_BACKTRACE
+#endif // #ifndef ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01
+
+#if ( ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 != 0 )
 // This function should not be static - otherwise it won't show up on the stack trace
 // static
 void capturing_stack_trace( void** testFixtureState )
@@ -81,6 +90,7 @@ void capturing_stack_trace( void** testFixtureState )
     assert_ptr_not_equal( strstr( stackTraceAsString, __FUNCTION__ ), NULL );
     #endif
 }
+#endif // ##if ( ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 != 0 )
 
 int run_platform_tests()
 {
@@ -88,7 +98,9 @@ int run_platform_tests()
     {
         ELASTIC_APM_CMOCKA_UNIT_TEST( stream_errno ),
         ELASTIC_APM_CMOCKA_UNIT_TEST( stream_errno_overflow ),
+#       if ( ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 != 0 )
         ELASTIC_APM_CMOCKA_UNIT_TEST( capturing_stack_trace ),
+#       endif // ##if ( ELASTIC_APM_CAN_CAPTURE_STACK_TRACE_01 != 0 )
     };
 
     return cmocka_run_group_tests( tests, NULL, NULL );

--- a/src/ext/unit_tests/platform_tests.c
+++ b/src/ext/unit_tests/platform_tests.c
@@ -44,9 +44,15 @@ void stream_errno( void** testFixtureState )
     ELASTIC_APM_CMOCKA_ASSERT_STRING_CONTAINS_IGNORE_CASE( ENOENT_str, "directory" );
 
     const String non_existing_errno_str = streamErrNo( 999, &txtOutStream );
+    #ifdef PHP_WIN32
     ELASTIC_APM_CMOCKA_ASSERT_STRING_CONTAINS_IGNORE_CASE( non_existing_errno_str, "Unknown" );
-    #ifndef PHP_WIN32
+    #else
+    #   ifdef __GLIBC__
+    ELASTIC_APM_CMOCKA_ASSERT_STRING_CONTAINS_IGNORE_CASE( non_existing_errno_str, "Unknown" );
     ELASTIC_APM_CMOCKA_ASSERT_STRING_CONTAINS_IGNORE_CASE( non_existing_errno_str, "999" );
+    #   else
+    ELASTIC_APM_CMOCKA_ASSERT_STRING_CONTAINS_IGNORE_CASE( non_existing_errno_str, "No error information" );
+    #   endif
     #endif
 }
 


### PR DESCRIPTION
Disable C-part unit tests for stack trace capture on Alpine Linux because Alpine Linux doesn't have backtrace