### PR TITLE
[CI] cache docker images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -15,4 +15,11 @@ if [ -x "$(command -v docker)" ]; then
   do
   (retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"
   done
+
+  for version in 7.2 7.3 7.4
+  do
+    PHP_VERSION=${version} make -f .ci/Makefile prepare || true
+    DOCKERFILE=Dockerfile.alpine PHP_VERSION=${version} make -f .ci/Makefile prepare || true
+    PHP_VERSION=${version} make -C packaging prepare || true
+  done
 fi


### PR DESCRIPTION
### What

Build and cache the docker images to run faster builds

Required size ~ 2gb
```bash
$ docker images | grep php       
test-php                                                                 7.4-alpine             1b289879146c        About a minute ago   347MB
test-php                                                                 7.4                    429f63bd4e7e        About a minute ago   413MB
test-php                                                                 7.3-alpine             18f004b8a8f7        About a minute ago   340MB
test-php                                                                 7.3                    bfb0e5dbcc85        About a minute ago   406MB
php-packaging                                                            latest                 2cd4e612ec19        2 minutes ago        373MB
test-php                                                                 7.2-alpine             f7339851827f        2 minutes ago        340MB
test-php                                                                 7.2                    d2ac2f456c64        3 hours ago          405MB
```

