### PR TITLE
[CI] Transform phpstan to junit

### DIFF
--- a/.ci/static-check-unit-test.sh
+++ b/.ci/static-check-unit-test.sh
@@ -38,3 +38,6 @@ composer install
 
 # Run static_check_and_run_unit_tests
 composer run-script static_check_and_run_unit_tests
+
+# Generate junit output for phpstan
+composer phpstan-junit-report-for-ci

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
         ],
         "phpstan": [
             "phpstan analyse -c ./phpstan.neon ./src/ElasticApm/ --level max --memory-limit=200M",
-            "phpstan analyse -c ./phpstan.neon ./tests/ --level max --memory-limit=200M --error-format=junit",
-            "phpstan analyse -c ./phpstan.neon ./examples/ --level max --memory-limit=200M --error-format=junit"
+            "phpstan analyse -c ./phpstan.neon ./tests/ --level max --memory-limit=200M",
+            "phpstan analyse -c ./phpstan.neon ./examples/ --level max --memory-limit=200M"
         ],
         "static_check": [
             "composer run-script php_codesniffer_check",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,11 @@
             "phpstan analyse --error-format=junit -c ./phpstan.neon ./tests/ --level max --memory-limit=200M --error-format=junit | tee build/tests-phpstan-junit.xml",
             "phpstan analyse --error-format=junit -c ./phpstan.neon ./examples/ --level max --memory-limit=200M --error-format=junit | tee build/examples-phpstan-junit.xml"
         ],
+        "phpstan": [
+            "phpstan analyse -c ./phpstan.neon ./src/ElasticApm/ --level max --memory-limit=200M",
+            "phpstan analyse -c ./phpstan.neon ./tests/ --level max --memory-limit=200M --error-format=junit",
+            "phpstan analyse -c ./phpstan.neon ./examples/ --level max --memory-limit=200M --error-format=junit"
+        ],
         "static_check": [
             "composer run-script php_codesniffer_check",
             "composer run-script phpstan"

--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,10 @@
             "phpcbf ./tests",
             "phpcbf ./examples/"
         ],
-        "phpstan": [
-            "phpstan analyse -c ./phpstan.neon ./src/ElasticApm/ --level max --memory-limit=200M",
-            "phpstan analyse -c ./phpstan.neon ./tests/ --level max --memory-limit=200M",
-            "phpstan analyse -c ./phpstan.neon ./examples/ --level max --memory-limit=200M"
+        "phpstan-junit-report-for-ci": [
+            "phpstan analyse --error-format=junit -c ./phpstan.neon ./src/ElasticApm/ --level max --memory-limit=200M | tee build/elasticapm-phpstan-junit.xml",
+            "phpstan analyse --error-format=junit -c ./phpstan.neon ./tests/ --level max --memory-limit=200M --error-format=junit | tee build/tests-phpstan-junit.xml",
+            "phpstan analyse --error-format=junit -c ./phpstan.neon ./examples/ --level max --memory-limit=200M --error-format=junit | tee build/examples-phpstan-junit.xml"
         ],
         "static_check": [
             "composer run-script php_codesniffer_check",


### PR DESCRIPTION
### What

Add new composer script to trigger the phpstan with junit output.

It duplicates `phpstan` since I could not find the way to run OS agnostic and configure the report format, default is `table`.

NOTE: if no failures then the junit report will contain 0 tests.

### Issues

Closes https://github.com/elastic/apm-agent-php/issues/263