### PR TITLE
TEST for "Unit tests should fail immediately if elastic_apm extension is loaded"

### DIFF
--- a/examples/ElasticApmExamples/UsingPublicApi/ExampleUsingPublicApi.php
+++ b/examples/ElasticApmExamples/UsingPublicApi/ExampleUsingPublicApi.php
@@ -9,7 +9,6 @@ namespace Elastic\Apm\Examples\UsingPublicApi;
 use Elastic\Apm\Impl\TracerBuilder;
 use Elastic\Apm\Tests\UnitTests\Util\MockEventSink;
 use Elastic\Apm\Tests\UnitTests\Util\UnitTestCaseBase;
-use Elastic\Apm\TransactionInterface;
 
 class ExampleUsingPublicApi extends UnitTestCaseBase
 {

--- a/src/ElasticApm/Impl/AutoInstrument/PhpPartFacade.php
+++ b/src/ElasticApm/Impl/AutoInstrument/PhpPartFacade.php
@@ -7,6 +7,7 @@ namespace Elastic\Apm\Impl\AutoInstrument;
 use Elastic\Apm\Impl\GlobalTracerHolder;
 use Elastic\Apm\Impl\Tracer;
 use Elastic\Apm\Impl\Util\Assert;
+use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 use Elastic\Apm\Impl\Util\HiddenConstructorTrait;
 use RuntimeException;
 use Throwable;
@@ -34,8 +35,8 @@ final class PhpPartFacade
 
     private function __construct(float $requestInitStartTime)
     {
-        if (!extension_loaded('elastic_apm')) {
-            throw new RuntimeException('elastic_apm extension is not loaded');
+        if (!ElasticApmExtensionUtil::isLoaded()) {
+            throw new RuntimeException(ElasticApmExtensionUtil::EXTENSION_NAME . ' extension is not loaded');
         }
 
         $tracer = self::buildTracer();

--- a/src/ElasticApm/Impl/BackendComm/EventSender.php
+++ b/src/ElasticApm/Impl/BackendComm/EventSender.php
@@ -62,24 +62,22 @@ final class EventSender implements EventSinkInterface
             $serializedEvents .= "}";
         }
 
-        if (extension_loaded('elastic_apm')) {
-            ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
-            && $loggerProxy->log(
-                'Calling elastic_apm_send_to_server...',
-                [
-                    'serverTimeout' => $this->config->serverTimeout(),
-                    'strlen($serializedMetadata)' => strlen($serializedMetadata),
-                    'strlen($serializedEvents)' => strlen($serializedEvents),
-                ]
-            );
+        ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
+        && $loggerProxy->log(
+            'Calling elastic_apm_send_to_server...',
+            [
+                'serverTimeout'               => $this->config->serverTimeout(),
+                'strlen($serializedMetadata)' => strlen($serializedMetadata),
+                'strlen($serializedEvents)'   => strlen($serializedEvents),
+            ]
+        );
 
-            /**
-             * elastic_apm_* functions are provided by the elastic_apm extension
-             *
-             * @noinspection PhpFullyQualifiedNameUsageInspection, PhpUndefinedFunctionInspection
-             * @phpstan-ignore-next-line
-             */
-            \elastic_apm_send_to_server($this->config->serverTimeout(), $serializedMetadata, $serializedEvents);
-        }
+        /**
+         * elastic_apm_* functions are provided by the elastic_apm extension
+         *
+         * @noinspection PhpFullyQualifiedNameUsageInspection, PhpUndefinedFunctionInspection
+         * @phpstan-ignore-next-line
+         */
+        \elastic_apm_send_to_server($this->config->serverTimeout(), $serializedMetadata, $serializedEvents);
     }
 }

--- a/src/ElasticApm/Impl/Log/Backend.php
+++ b/src/ElasticApm/Impl/Log/Backend.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Elastic\Apm\Impl\Log;
 
 use Elastic\Apm\Impl\Util\DbgUtil;
+use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -22,7 +23,10 @@ final class Backend
     public function __construct(int $maxEnabledLevel, ?SinkInterface $logSink)
     {
         $this->maxEnabledLevel = $maxEnabledLevel;
-        $this->logSink = $logSink ?? new DefaultSink();
+        $this->logSink = $logSink ??
+                         (ElasticApmExtensionUtil::isLoaded()
+                             ? new DefaultSink()
+                             : NoopLogSink::singletonInstance());
     }
 
     public function maxEnabledLevel(): int

--- a/src/ElasticApm/Impl/Log/NoopLogSink.php
+++ b/src/ElasticApm/Impl/Log/NoopLogSink.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Elastic\Apm\Tests\Util;
+namespace Elastic\Apm\Impl\Log;
 
-use Elastic\Apm\Impl\Log\SinkInterface;
+use Elastic\Apm\Impl\Util\NoopObjectTrait;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -13,6 +13,8 @@ use Elastic\Apm\Impl\Log\SinkInterface;
  */
 final class NoopLogSink implements SinkInterface
 {
+    use NoopObjectTrait;
+
     public function consume(
         int $statementLevel,
         string $message,

--- a/src/ElasticApm/Impl/Tracer.php
+++ b/src/ElasticApm/Impl/Tracer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Elastic\Apm\Impl;
 
 use Closure;
+use Elastic\Apm\Impl\BackendComm\EventSender;
 use Elastic\Apm\Impl\Config\AllOptionsMetadata;
 use Elastic\Apm\Impl\Config\CompositeRawSnapshotSource;
 use Elastic\Apm\Impl\Config\EnvVarsRawSnapshotSource;
@@ -16,7 +17,7 @@ use Elastic\Apm\Impl\Log\Level as LogLevel;
 use Elastic\Apm\Impl\Log\LogCategory;
 use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\Log\LoggerFactory;
-use Elastic\Apm\Impl\BackendComm\EventSender;
+use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 use Elastic\Apm\Impl\Util\ObjectToStringBuilder;
 use Elastic\Apm\Impl\Util\TextUtil;
 use Elastic\Apm\TransactionInterface;
@@ -68,7 +69,10 @@ final class Tracer implements TracerInterface
         $this->logger = $this->loggerFactory
             ->loggerForClass(LogCategory::PUBLIC_API, __NAMESPACE__, __CLASS__, __FILE__);
 
-        $this->eventSink = $providedDependencies->eventSink ?? new EventSender($this->config, $this->loggerFactory);
+        $this->eventSink = $providedDependencies->eventSink ??
+                           (ElasticApmExtensionUtil::isLoaded()
+                               ? new EventSender($this->config, $this->loggerFactory)
+                               : NoopEventSink::singletonInstance());
 
         $this->currentTransaction = null;
 

--- a/src/ElasticApm/Impl/Util/ElasticApmExtensionUtil.php
+++ b/src/ElasticApm/Impl/Util/ElasticApmExtensionUtil.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Impl\Util;
+
+/**
+ * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
+ *
+ * @internal
+ */
+final class ElasticApmExtensionUtil
+{
+    use StaticClassTrait;
+
+    public const EXTENSION_NAME = 'elastic_apm';
+
+    /** @var bool */
+    private static $isLoaded;
+
+    public static function isLoaded(): bool
+    {
+        if (!isset(self::$isLoaded)) {
+            self::$isLoaded = extension_loaded(self::EXTENSION_NAME);
+        }
+
+        return self::$isLoaded;
+    }
+}

--- a/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
@@ -6,6 +6,7 @@ namespace Elastic\Apm\Tests\ComponentTests\Util;
 
 use Elastic\Apm\ElasticApm;
 use Elastic\Apm\Impl\Log\Logger;
+use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 use Elastic\Apm\Tests\Util\LogCategoryForTests;
 use RuntimeException;
 use Throwable;
@@ -17,9 +18,10 @@ abstract class AppCodeHostBase extends CliProcessBase
 
     public function __construct()
     {
-        if (!extension_loaded('elastic_apm')) {
+        if (!ElasticApmExtensionUtil::isLoaded()) {
             throw new RuntimeException(
-                'Environment hosting component tests application code should have elastic_apm extension loaded.'
+                'Environment hosting component tests application code should have '
+                . ElasticApmExtensionUtil::EXTENSION_NAME . ' extension loaded.'
                 . ' php_ini_loaded_file(): ' . php_ini_loaded_file() . '.'
             );
         }

--- a/tests/ElasticApmTests/UnitTests/Util/EmptyConfigRawSnapshotSource.php
+++ b/tests/ElasticApmTests/UnitTests/Util/EmptyConfigRawSnapshotSource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Tests\UnitTests\Util;
+
+use Elastic\Apm\Impl\Config\RawSnapshotFromArray;
+use Elastic\Apm\Impl\Config\RawSnapshotInterface;
+use Elastic\Apm\Impl\Config\RawSnapshotSourceInterface as ConfigRawSnapshotSourceInterface;
+
+final class EmptyConfigRawSnapshotSource implements ConfigRawSnapshotSourceInterface
+{
+    public function currentSnapshot(array $optionNameToMeta): RawSnapshotInterface
+    {
+        return EmptyRawSnapshot::singletonInstance();
+    }
+}

--- a/tests/ElasticApmTests/UnitTests/Util/EmptyRawSnapshot.php
+++ b/tests/ElasticApmTests/UnitTests/Util/EmptyRawSnapshot.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Tests\UnitTests\Util;
+
+use Elastic\Apm\Impl\Config\RawSnapshotInterface;
+use Elastic\Apm\Impl\Util\SingletonInstanceTrait;
+
+final class EmptyRawSnapshot implements RawSnapshotInterface
+{
+    use SingletonInstanceTrait;
+
+    public function valueFor(string $optionName): ?string
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Unit tests should fail immediately if elastic_apm extension is loaded because it will cause a clash.