### PR TITLE
[CI] PHPUnit to JUnit

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                 }
                 post {
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
                   }
                 }
               }
@@ -231,7 +231,7 @@ pipeline {
                 }
                 post {
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
                   }
                 }
               }
@@ -330,7 +330,7 @@ pipeline {
                     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* got some test failures in the installers.", body: "Please review the signed binaries are healthy (<${env.RUN_DISPLAY_URL}|Open>)")
                   }
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
                   }
                 }
               }
@@ -386,7 +386,7 @@ pipeline {
                     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published with some test failures in the installers.", body: "Please review the signed and released binaries are healthy\nBuild: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
                   }
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
                   }
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                 }
                 post {
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/*junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/*junit.xml,${BASE_DIR}/phpunit-junit.xml")
                   }
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                 }
                 post {
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
                   }
                 }
               }
@@ -231,7 +231,7 @@ pipeline {
                 }
                 post {
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
                   }
                 }
               }
@@ -330,7 +330,7 @@ pipeline {
                     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* got some test failures in the installers.", body: "Please review the signed binaries are healthy (<${env.RUN_DISPLAY_URL}|Open>)")
                   }
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
                   }
                 }
               }
@@ -386,7 +386,7 @@ pipeline {
                     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published with some test failures in the installers.", body: "Please review the signed and released binaries are healthy\nBuild: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
                   }
                   always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml")
+                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/log_as_junit.xml,${BASE_DIR}/phpunit-*junit.xml")
                   }
                 }
               }

--- a/.ci/loop.sh
+++ b/.ci/loop.sh
@@ -6,7 +6,7 @@ PHP_VERSION=${3:-7.2}
 
 OUTPUT_FOLDER="build/loop-$DOCKERFILE-$PHP_VERSION"
 TEST_REPORT_TEST="junit.xml"
-TEST_REPORT_COMPOSER="_GENERATED/COMPONENT_TESTS/log_as_junit.xml"
+TEST_REPORT_COMPOSER="build/phpunit-component-junit.xml"
 mkdir -p "${OUTPUT_FOLDER}" || true
 
 for (( c=1; c<=LOOPS; c++ ))

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ docker/wordpress/data/ext
 # Mac
 .DS_Store
 
-# JUnit
-junit.xml
-
 # JetBrains PhpStorm
 .idea/
 
@@ -16,9 +13,6 @@ junit.xml
 
 # Visual Studio Code
 .vscode/
-
-# Generated files
-_GENERATED/
 
 # Composer
 composer.lock
@@ -33,7 +27,6 @@ vendor/
 # This allows a developer to use a custom configuration without running the risk of accidentally checking it into version control.
 phpunit.xml
 .phpunit.result.cache
-phpunit-*junit.xml
 
 # Built documentation
 html_docs

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ vendor/
 # This allows a developer to use a custom configuration without running the risk of accidentally checking it into version control.
 phpunit.xml
 .phpunit.result.cache
+phpunit-junit.xml
 
 # Built documentation
 html_docs

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ vendor/
 # This allows a developer to use a custom configuration without running the risk of accidentally checking it into version control.
 phpunit.xml
 .phpunit.result.cache
-phpunit-junit.xml
+phpunit-*junit.xml
 
 # Built documentation
 html_docs

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ docker/wordpress/data/ext
 
 # Generated files
 _GENERATED/
+
 # Composer
 composer.lock
 composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ docker/wordpress/data/ext
 # Visual Studio Code
 .vscode/
 
+# Generated files
+_GENERATED/
 # Composer
 composer.lock
 composer.phar

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
         <ini name="memory_limit" value="2G" />
     </php>
 
+    <logging>
+        <log type="junit" target="phpunit-junit.xml"/>
+    </logging>
+
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/ElasticApmTests/UnitTests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
     </php>
 
     <logging>
-        <log type="junit" target="phpunit-junit.xml"/>
+        <log type="junit" target="build/phpunit-junit.xml"/>
     </logging>
 
     <testsuites>

--- a/phpunit_component_tests.xml
+++ b/phpunit_component_tests.xml
@@ -18,6 +18,10 @@
         <ini name="memory_limit" value="2G" />
     </php>
 
+    <logging>
+        <log type="junit" target="phpunit-component-junit.xml"/>
+    </logging>
+
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/ElasticApmTests/ComponentTests</directory>

--- a/phpunit_component_tests.xml
+++ b/phpunit_component_tests.xml
@@ -19,7 +19,7 @@
     </php>
 
     <logging>
-        <log type="junit" target="phpunit-component-junit.xml"/>
+        <log type="junit" target="build/phpunit-component-junit.xml"/>
     </logging>
 
     <testsuites>
@@ -35,7 +35,4 @@
     <extensions>
         <extension class="\Elastic\Apm\Tests\ComponentTests\Util\PhpUnitExtension" />
     </extensions>
-    <logging>
-        <log type="junit" target="./_GENERATED/COMPONENT_TESTS/log_as_junit.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
### What

Add JUnit reporting for the phpunit

See [php configuration detail](https://phpunit.readthedocs.io/en/8.5/configuration.html?highlight=junit#the-logging-element)

### Test

```bash
$ make -f .ci/Makefile static-check-unit-test
...
$ head -n 5 phpunit-junit.xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="Tests" tests="145" assertions="1426102" errors="0" warnings="0" failures="0" skipped="0" time="41.276056">
    <testsuite name="Elastic\Apm\Tests\UnitTests\CapturePublicApiTest" file="/app/tests/ElasticApmTests/UnitTests/CapturePublicApiTest.php" tests="5" assertions="83" errors="0" warnings="0" failures="0" skipped="0" time="0.468707">

```