### PR TITLE
Use ephemeral_id to investigate component tests flakiness

### DIFF
--- a/src/ElasticApm/Impl/BackendComm/EventSender.php
+++ b/src/ElasticApm/Impl/BackendComm/EventSender.php
@@ -22,9 +22,6 @@ final class EventSender implements EventSinkInterface
     /** @var Logger */
     private $logger;
 
-    /** @var Metadata */
-    private $metadata;
-
     /** @var ConfigSnapshot */
     private $config;
 
@@ -35,15 +32,11 @@ final class EventSender implements EventSinkInterface
         $this->logger->addContext('this', $this);
     }
 
-    public function setMetadata(Metadata $metadata): void
-    {
-        $this->metadata = $metadata;
-    }
-
-    public function consume(array $spansData, ?TransactionData $transactionData): void
+    /** @inheritDoc */
+    public function consume(Metadata $metadata, array $spansData, ?TransactionData $transactionData): void
     {
         $serializedMetadata = '{"metadata":';
-        $serializedMetadata .= SerializationUtil::serializeAsJson($this->metadata);
+        $serializedMetadata .= SerializationUtil::serializeAsJson($metadata);
         $serializedMetadata .= "}";
 
         $serializedEvents = $serializedMetadata;

--- a/src/ElasticApm/Impl/EventSinkInterface.php
+++ b/src/ElasticApm/Impl/EventSinkInterface.php
@@ -11,11 +11,10 @@ namespace Elastic\Apm\Impl;
  */
 interface EventSinkInterface
 {
-    public function setMetadata(Metadata $metadata): void;
-
     /**
+     * @param Metadata             $metadata
      * @param SpanData[]           $spansData
      * @param TransactionData|null $transactionData
      */
-    public function consume(array $spansData, ?TransactionData $transactionData): void;
+    public function consume(Metadata $metadata, array $spansData, ?TransactionData $transactionData): void;
 }

--- a/src/ElasticApm/Impl/MetadataDiscoverer.php
+++ b/src/ElasticApm/Impl/MetadataDiscoverer.php
@@ -56,7 +56,9 @@ final class MetadataDiscoverer
             $result->version = Tracer::limitKeywordString($config->serviceVersion());
         }
 
-        $result->agent = self::buildNameVersionData(self::AGENT_NAME, ElasticApm::VERSION);
+        $result->agent = new ServiceAgentData();
+        $result->agent->name = self::AGENT_NAME;
+        $result->agent->version = ElasticApm::VERSION;
 
         $result->language = self::buildNameVersionData(MetadataDiscoverer::LANGUAGE_NAME, PHP_VERSION);
 

--- a/src/ElasticApm/Impl/NoopEventSink.php
+++ b/src/ElasticApm/Impl/NoopEventSink.php
@@ -15,11 +15,8 @@ final class NoopEventSink implements EventSinkInterface
 {
     use NoopObjectTrait;
 
-    public function setMetadata(Metadata $metadata): void
-    {
-    }
-
-    public function consume(array $spansData, ?TransactionData $transactionData): void
+    /** @inheritDoc */
+    public function consume(Metadata $metadata, array $spansData, ?TransactionData $transactionData): void
     {
     }
 }

--- a/src/ElasticApm/Impl/NoopSpan.php
+++ b/src/ElasticApm/Impl/NoopSpan.php
@@ -17,28 +17,34 @@ final class NoopSpan extends NoopExecutionSegment implements SpanInterface
 {
     use NoopObjectTrait;
 
+    /** @inheritDoc */
     public function getTransactionId(): string
     {
         return NoopTransaction::ID;
     }
 
+    /** @inheritDoc */
     public function getParentId(): string
     {
         return NoopTransaction::ID;
     }
 
+    /** @inheritDoc */
     public function setSubtype(?string $subtype): void
     {
     }
 
+    /** @inheritDoc */
     public function setAction(?string $action): void
     {
     }
 
+    /** @inheritDoc */
     public function endSpanEx(int $numberOfStackFramesToSkip, ?float $duration = null): void
     {
     }
 
+    /** @inheritDoc */
     public function context(): SpanContextInterface
     {
         return NoopSpanContext::singletonInstance();

--- a/src/ElasticApm/Impl/NoopTracer.php
+++ b/src/ElasticApm/Impl/NoopTracer.php
@@ -49,21 +49,24 @@ final class NoopTracer implements TracerInterface
         return NoopTransaction::singletonInstance();
     }
 
+    /** @inheritDoc */
     public function pauseRecording(): void
     {
     }
 
+    /** @inheritDoc */
     public function resumeRecording(): void
     {
     }
 
+    /** @inheritDoc */
     public function isRecording(): bool
     {
         return false;
     }
 
-    public function __toString(): string
+    /** @inheritDoc */
+    public function setAgentEphemeralId(?string $ephemeralId): void
     {
-        return 'NO-OP Tracer';
     }
 }

--- a/src/ElasticApm/Impl/ServiceAgentData.php
+++ b/src/ElasticApm/Impl/ServiceAgentData.php
@@ -14,34 +14,24 @@ use JsonSerializable;
  *
  * @internal
  */
-class NameVersionData implements JsonSerializable, LoggableInterface
+class ServiceAgentData extends NameVersionData
 {
-    use LoggableTrait;
-
     /**
      * @var string|null
      *
-     * Name of an entity.
+     * Free format ID used for metrics correlation by some agents.
      *
      * The length of this string is limited to 1024.
-     */
-    public $name = null;
-
-    /**
-     * @var string|null
      *
-     * Version of an entity, e.g."1.0.0".
-     *
-     * The length of this string is limited to 1024.
+     * @link https://github.com/elastic/apm-server/blob/7.2/docs/spec/service.json#L20
      */
-    public $version = null;
+    public $ephemeralId = null;
 
     public function jsonSerialize()
     {
-        $result = [];
+        $result = parent::jsonSerialize();
 
-        SerializationUtil::addNameValueIfNotNull('name', $this->name, /* ref */ $result);
-        SerializationUtil::addNameValueIfNotNull('version', $this->version, /* ref */ $result);
+        SerializationUtil::addNameValueIfNotNull('ephemeral_id', $this->ephemeralId, /* ref */ $result);
 
         return $result;
     }

--- a/src/ElasticApm/Impl/ServiceData.php
+++ b/src/ElasticApm/Impl/ServiceData.php
@@ -53,7 +53,7 @@ class ServiceData implements JsonSerializable, LoggableInterface
     public $environment = null;
 
     /**
-     * @var NameVersionData|null
+     * @var ServiceAgentData|null
      *
      * Name and version of the Elastic APM agent.
      * Name of the Elastic APM agent, e.g. "php".

--- a/src/ElasticApm/Impl/TracerInterface.php
+++ b/src/ElasticApm/Impl/TracerInterface.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Elastic\Apm\Impl;
 
 use Closure;
+use Elastic\Apm\ElasticApm;
 use Elastic\Apm\TransactionInterface;
 
 interface TracerInterface
@@ -67,13 +68,35 @@ interface TracerInterface
      */
     public function captureCurrentTransaction(string $name, string $type, Closure $callback, ?float $timestamp = null);
 
+    /**
+     * @see ElasticApm::getCurrentTransaction()
+     */
     public function getCurrentTransaction(): TransactionInterface;
 
+    /**
+     * Returns true if this Tracer is a no-op (for example because Elastic APM is disabled)
+     */
     public function isNoop(): bool;
 
+    /**
+     * @see ElasticApm::pauseRecording()
+     */
     public function pauseRecording(): void;
 
+    /**
+     * @see ElasticApm::resumeRecording()
+     */
     public function resumeRecording(): void;
 
+    /**
+     * Returns true if this Tracer has recording on i.e., not paused
+     */
     public function isRecording(): bool;
+
+    /**
+     * @param string|null $ephemeralId
+     *
+     * @see ServiceAgentData::ephemeralId
+     */
+    public function setAgentEphemeralId(?string $ephemeralId): void;
 }

--- a/src/ElasticApm/Impl/Transaction.php
+++ b/src/ElasticApm/Impl/Transaction.php
@@ -251,7 +251,7 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
     public function queueSpanDataToSend(SpanData $spanData): void
     {
         if ($this->hasEnded()) {
-            $this->tracer->getEventSink()->consume([$spanData], /* transaction: */ null);
+            $this->tracer->sendEventsToApmServer([$spanData], /* transaction: */ null);
             return;
         }
 
@@ -268,7 +268,7 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
             $this->data->context = null;
         }
 
-        $this->tracer->getEventSink()->consume($this->spansDataToSend, $this->data);
+        $this->tracer->sendEventsToApmServer($this->spansDataToSend, $this->data);
 
         if ($this->tracer->getCurrentTransaction() === $this) {
             $this->tracer->resetCurrentTransaction();

--- a/tests/ElasticApmTests/ComponentTests/Util/SharedDataPerRequest.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/SharedDataPerRequest.php
@@ -21,6 +21,9 @@ final class SharedDataPerRequest extends SharedData
     /** @var string */
     public $serverId;
 
+    /** @var string */
+    public $agentEphemeralId;
+
     public static function fromServerId(string $serverId, ?SharedDataPerRequest $prototype = null): self
     {
         $result = new SharedDataPerRequest();

--- a/tests/ElasticApmTests/ComponentTests/Util/routeToCliBuiltinHttpServerAppCodeHost.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/routeToCliBuiltinHttpServerAppCodeHost.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\ComponentTests\Util;
 
 use Elastic\Apm\ElasticApm;
+use Elastic\Apm\Impl\GlobalTracerHolder;
 
 require __DIR__ . '/../../../bootstrap.php';
 require __DIR__ . '/defineTopLevelCodeIdGlobalVar.php';
@@ -12,6 +13,7 @@ require __DIR__ . '/defineTopLevelCodeIdGlobalVar.php';
 BuiltinHttpServerAppCodeHost::run(/* ref */ $globalTopLevelCodeId);
 
 if (!is_null($globalTopLevelCodeId)) {
+    AppCodeHostBase::setAgentEphemeralId();
     if ($globalTopLevelCodeId === TopLevelCodeId::SPAN_BEGIN_END) {
         $span = ElasticApm::getCurrentTransaction()->beginCurrentSpan(
             'top_level_code_span_name',

--- a/tests/ElasticApmTests/ComponentTests/Util/runCliScriptAppCodeHost.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/runCliScriptAppCodeHost.php
@@ -12,6 +12,7 @@ require __DIR__ . '/defineTopLevelCodeIdGlobalVar.php';
 CliScriptAppCodeHost::run(/* ref */ $globalTopLevelCodeId);
 
 if (!is_null($globalTopLevelCodeId)) {
+    AppCodeHostBase::setAgentEphemeralId();
     if ($globalTopLevelCodeId === TopLevelCodeId::SPAN_BEGIN_END) {
         $span = ElasticApm::getCurrentTransaction()->beginCurrentSpan(
             'top_level_code_span_name',

--- a/tests/ElasticApmTests/UnitTests/Util/MockEventSink.php
+++ b/tests/ElasticApmTests/UnitTests/Util/MockEventSink.php
@@ -66,7 +66,21 @@ class MockEventSink implements EventSinkInterface
         return $deserializedData;
     }
 
-    public function setMetadata(Metadata $metadata): void
+    /** @inheritDoc */
+    public function consume(Metadata $metadata, array $spansData, ?TransactionData $transactionData): void
+    {
+        $this->consumeMetadata($metadata);
+
+        foreach ($spansData as $span) {
+            $this->consumeSpanData($span);
+        }
+
+        if (!is_null($transactionData)) {
+            $this->consumeTransactionData($transactionData);
+        }
+    }
+
+    private function consumeMetadata(Metadata $metadata): void
     {
         $this->eventsFromAgent->metadata[] = self::passThroughSerialization(
             $metadata,
@@ -88,17 +102,6 @@ class MockEventSink implements EventSinkInterface
                 TestCase::assertEquals($data, $deserializedData);
             }
         );
-    }
-
-    public function consume(array $spansData, ?TransactionData $transactionData): void
-    {
-        foreach ($spansData as $span) {
-            $this->consumeSpanData($span);
-        }
-
-        if (!is_null($transactionData)) {
-            $this->consumeTransactionData($transactionData);
-        }
     }
 
     private function consumeTransactionData(TransactionData $transaction): void

--- a/tests/ElasticApmTests/Util/Deserialization/ServiceDataDeserializer.php
+++ b/tests/ElasticApmTests/Util/Deserialization/ServiceDataDeserializer.php
@@ -58,7 +58,7 @@ final class ServiceDataDeserializer extends DataDeserializer
                 return true;
 
             case 'agent':
-                $this->result->agent = NameVersionDataDeserializer::deserialize($value);
+                $this->result->agent = ServiceAgentDataDeserializer::deserialize($value);
                 return true;
 
             case 'framework':

--- a/tests/ElasticApmTests/Util/ValidationUtil.php
+++ b/tests/ElasticApmTests/Util/ValidationUtil.php
@@ -388,6 +388,7 @@ final class ValidationUtil
         TestCase::assertNotNull($serviceData->agent);
         self::assertThat($serviceData->agent->name === MetadataDiscoverer::AGENT_NAME);
         self::assertThat($serviceData->agent->version === ElasticApm::VERSION);
+        self::assertValidNullableKeywordString($serviceData->agent->ephemeralId);
 
         self::assertValidNameVersionData($serviceData->framework);
 


### PR DESCRIPTION
Namely to assert all the data received by mock APM Server is indeed from the agent spawned by the current test case.