### PR TITLE
[CI] Fix the single quote issue when raising PRs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -444,10 +444,10 @@ def prepareRelease() {
   def actions = """### Actions
 * If changes are fine then:
   1. [Approve](${env.BUILD_URL}input) it. The pipeline will take care of the release.
-  1. Close this PR since it's not required anymore.
+  1. Close this PR since it is not required anymore.
   1. Delete branch ${branchName}.
 * If changes are not correct then:
-  1. [abort](${env.BUILD_URL}input) it
+  1. [abort](${env.BUILD_URL}input) it.
   1. Change and commit changes to this PR.
   1. Merge this PR.
   1. Delete branch ${branchName}.


### PR DESCRIPTION
### What

`githubCreatePullRequest` step runs a shell step to interact with GitHub, and the message is not transformed to avoid any single quotes within it, therefore if not removed them it will cause a failure.


### Tests

Locally

![image](https://user-images.githubusercontent.com/2871786/98802416-35c0cc80-240b-11eb-9adc-ca85957509c7.png)

