### PR TITLE
[CI] Push with the step

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -470,8 +470,7 @@ def prepareRelease() {
       // Update branch.
       sh(label: "Git branch ${env.BRANCH_NAME}", script: """git checkout ${env.BRANCH_NAME}""")
       sh(label: 'Git rebase', script: """git rebase ${branchName}""")
-      sh(label: 'Git push', script: """git push origin ${env.BRANCH_NAME}""")
-      gitPush()
+      gitPush(args: "${env.BRANCH_NAME}")
       gitCreateTag(tag: "${tagName}")
     } else {
       log(level: 'WARN', text: "Please review the PR ${pr}")


### PR DESCRIPTION
### What

Use the gitPush step since the gitRelease context was cleaned up after running the `githubCreatePullRequest`, therefore the credentials were not anymore in place.

### Why

Fix the release process automation

### Tests

Locally -> https://github.com/v1v/apm-agent-php/commits/v0.0.9

![image](https://user-images.githubusercontent.com/2871786/98812731-e4b8d480-241a-11eb-8671-6a82d50bc31c.png)


