### PR TITLE
[CI] speed builds, component tests run in the packaging

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -137,20 +137,6 @@ pipeline {
                   }
                 }
               }
-              stage('Component Tests') {
-                steps {
-                  withGithubNotify(context: "Component-Tests-${PHP_VERSION}", tab: 'tests') {
-                    dir("${BASE_DIR}"){
-                      sh script: "PHP_VERSION=${PHP_VERSION} DOCKERFILE=${DOCKERFILE} make -f .ci/Makefile component-test", label: 'component-test'
-                    }
-                  }
-                }
-                post {
-                  always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
-                  }
-                }
-              }
             }
           }
         }
@@ -216,16 +202,20 @@ pipeline {
                 name 'PHP_VERSION'
                 values '7.2', '7.3', '7.4'
               }
+              axis {
+                name 'DIST'
+                values 'apk', 'deb', 'rpm', 'tar'
+              }
             }
             stages {
               stage('Uninstallation testing') {
                 steps {
-                  withGithubNotify(context: "Package-Test-${PHP_VERSION}") {
+                  withGithubNotify(context: "Package-Test-${PHP_VERSION}-${DIST}") {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
                       unstash 'package'
-                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging uninstall", label: 'package uninstall'
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging ${DIST}-uninstall", label: "package uninstall ${PHP_VERSION}-${DIST}"
                     }
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -208,9 +208,9 @@ pipeline {
               }
             }
             stages {
-              stage("PHP=${PHP_VERSION},Dist=${DIST}") {
+              stage('Lifecycle Testing') {
                 steps {
-                  withGithubNotify(context: "Package-Test-${PHP_VERSION}-${DIST}") {
+                  withGithubNotify(context: "Lifecycle-Testing-${PHP_VERSION}-${DIST}") {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -188,7 +188,7 @@ pipeline {
             }
           }
         }
-        stage('Package-Test') {
+        stage('Package lifecycle testing') {
           when {
             beforeAgent true
             expression { return env.ONLY_DOCS == "false" }
@@ -208,14 +208,14 @@ pipeline {
               }
             }
             stages {
-              stage('Uninstallation testing') {
+              stage("PHP=${PHP_VERSION},Dist=${DIST}") {
                 steps {
                   withGithubNotify(context: "Package-Test-${PHP_VERSION}-${DIST}") {
                     deleteDir()
                     unstash 'source'
                     dir("${BASE_DIR}"){
                       unstash 'package'
-                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging ${DIST}-uninstall", label: "package uninstall ${PHP_VERSION}-${DIST}"
+                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging ${DIST}-lifecycle-testing", label: "${DIST}-lifecycle-testing for ${PHP_VERSION}"
                     }
                   }
                 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,6 +64,9 @@ make -C packaging deb-install
 ## To test the installation for a given release in debian using the downloaded binary
 RELEASE_VERSION=0.1 make -C packaging deb-install-release-github
 
+## To test the installation and uninstallation for all the packages
+make -C packaging lifecycle-testing
+
 ## Help goal will provide further details
 make -C packaging help
 ```

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -147,21 +147,21 @@ tar-install-release-github: prepare-tar  ## Install the tar installer from a giv
 .PHONY: install-release-github
 install-release-github: apk-install-release-github deb-install-release-github rpm-install-release-github tar-install-release-github  ## Install all the distributions for a given release using the downloaded binaries
 
-.PHONY: uninstall
-uninstall: apk-uninstall deb-uninstall rpm-uninstall tar-uninstall ## Uninstall all the distributions
+.PHONY: lifecycle-testing
+lifecycle-testing: apk-lifecycle-testing deb-lifecycle-testing rpm-lifecycle-testing tar-lifecycle-testing ## Lifecycle testing all the distributions
 
-.PHONY: apk-uninstall
-apk-uninstall: prepare-apk  ## Uninstallation testing for the apk installer
+.PHONY: apk-lifecycle-testing
+apk-lifecycle-testing: prepare-apk  ## Lifecycle testing for the apk installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=apk-uninstall -e PACKAGE=$(NAME) prepare-apk
 
-.PHONY: deb-uninstall
-deb-uninstall: prepare-deb  ## Uninstallation testing for the deb installer
+.PHONY: deb-lifecycle-testing
+deb-lifecycle-testing: prepare-deb  ## Lifecycle testing for the deb installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=deb-uninstall -e PACKAGE=$(NAME) prepare-deb
 
-.PHONY: rpm-uninstall
-rpm-uninstall: prepare-rpm  ## Uninstallation testing for the rpm installer
+.PHONY: rpm-lifecycle-testing
+rpm-lifecycle-testing: prepare-rpm  ## Lifecycle testing for the rpm installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=rpm-uninstall -e PACKAGE=$(NAME) prepare-rpm
 
-.PHONY: tar-uninstall
-tar-uninstall: prepare-tar  ## Uninstallation testing for the tar installer
+.PHONY: tar-lifecycle-testing
+tar-lifecycle-testing: prepare-tar  ## Lifecycle testing for the tar installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=tar-uninstall prepare-tar

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -161,3 +161,7 @@ deb-uninstall: prepare-deb  ## Uninstallation testing for the deb installer
 .PHONY: rpm-uninstall
 rpm-uninstall: prepare-rpm  ## Uninstallation testing for the rpm installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=rpm-uninstall -e PACKAGE=$(NAME) prepare-rpm
+
+.PHONY: tar-uninstall
+tar-uninstall: prepare-tar  ## Install the tar installer to run some smoke tests
+	@docker run --rm -v $(PWD):/src -w /src -e TYPE=tar-uninstall prepare-tar

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -148,7 +148,7 @@ tar-install-release-github: prepare-tar  ## Install the tar installer from a giv
 install-release-github: apk-install-release-github deb-install-release-github rpm-install-release-github tar-install-release-github  ## Install all the distributions for a given release using the downloaded binaries
 
 .PHONY: uninstall
-uninstall: apk-uninstall deb-uninstall rpm-uninstall  ## Uninstall all the distributions
+uninstall: apk-uninstall deb-uninstall rpm-uninstall tar-uninstall ## Uninstall all the distributions
 
 .PHONY: apk-uninstall
 apk-uninstall: prepare-apk  ## Uninstallation testing for the apk installer
@@ -163,5 +163,5 @@ rpm-uninstall: prepare-rpm  ## Uninstallation testing for the rpm installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=rpm-uninstall -e PACKAGE=$(NAME) prepare-rpm
 
 .PHONY: tar-uninstall
-tar-uninstall: prepare-tar  ## Install the tar installer to run some smoke tests
+tar-uninstall: prepare-tar  ## Uninstallation testing for the tar installer
 	@docker run --rm -v $(PWD):/src -w /src -e TYPE=tar-uninstall prepare-tar

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -42,12 +42,12 @@ elif [ "${TYPE}" == "release-tar-github" ] ; then
     ## Install tar package and configure the agent accordingly
     tar -xf ${BUILD_RELEASES_FOLDER}/${PACKAGE} -C /
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/post-install
+    source /opt/elastic/apm-agent-php/bin/post-install.sh
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/post-install
+    source /opt/elastic/apm-agent-php/bin/post-install.sh
 fi
 
 ## Verify if the elastic php agent is enabled
@@ -77,7 +77,7 @@ if [ "${TYPE}" == "rpm-uninstall" ] ; then
     fi
 elif [ "${TYPE}" == "tar-uninstall" ] ; then
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/before-uninstall
+    source /opt/elastic/apm-agent-php/bin/before-uninstall.sh
     ## Verify if the elastic php agent has been uninstalled
     php -m > /dev/null 2>&1
     if php -m | grep -q 'elastic' ; then

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -42,12 +42,12 @@ elif [ "${TYPE}" == "release-tar-github" ] ; then
     ## Install tar package and configure the agent accordingly
     tar -xf ${BUILD_RELEASES_FOLDER}/${PACKAGE} -C /
     # shellcheck disable=SC1091
-    source /.scripts/after_install
+    source /opt/elastic/apm-agent-php/bin/post-install
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /
     # shellcheck disable=SC1091
-    source /.scripts/after_install
+    source /opt/elastic/apm-agent-php/bin/post-install
 fi
 
 ## Verify if the elastic php agent is enabled
@@ -77,7 +77,7 @@ if [ "${TYPE}" == "rpm-uninstall" ] ; then
     fi
 elif [ "${TYPE}" == "tar-uninstall" ] ; then
     # shellcheck disable=SC1091
-    source /.scripts/before_uninstall
+    source /opt/elastic/apm-agent-php/bin/before-uninstall
     ## Verify if the elastic php agent has been uninstalled
     php -m > /dev/null 2>&1
     if php -m | grep -q 'elastic' ; then

--- a/packaging/test/centos/entrypoint.sh
+++ b/packaging/test/centos/entrypoint.sh
@@ -75,4 +75,13 @@ if [ "${TYPE}" == "rpm-uninstall" ] ; then
         echo 'Extension has not been uninstalled.'
         exit 1
     fi
+elif [ "${TYPE}" == "tar-uninstall" ] ; then
+    # shellcheck disable=SC1091
+    source /.scripts/before_uninstall
+    ## Verify if the elastic php agent has been uninstalled
+    php -m > /dev/null 2>&1
+    if php -m | grep -q 'elastic' ; then
+        echo 'Extension has not been uninstalled.'
+        exit 1
+    fi
 fi

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -42,12 +42,13 @@ elif [ "${TYPE}" == "release-tar-github" ] ; then
     ## Install tar package and configure the agent accordingly
     tar -xf ${BUILD_RELEASES_FOLDER}/${PACKAGE} -C /
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/after_install
+    source /opt/elastic/apm-agent-php/bin/post-install.sh
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /
+    ls -ltrah /opt/elastic/apm-agent-php/bin
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/post-install
+    source /opt/elastic/apm-agent-php/bin/post-install.sh
 fi
 
 ## Verify if the elastic php agent is enabled
@@ -77,7 +78,7 @@ if [ "${TYPE}" == "deb-uninstall" ] ; then
     fi
 elif [ "${TYPE}" == "tar-uninstall" ] ; then
     # shellcheck disable=SC1091
-    source /opt/elastic/apm-agent-php/bin/before-uninstall
+    source /opt/elastic/apm-agent-php/bin/before-uninstall.sh
     ## Verify if the elastic php agent has been uninstalled
     php -m > /dev/null 2>&1
     if php -m | grep -q 'elastic' ; then

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -75,4 +75,13 @@ if [ "${TYPE}" == "deb-uninstall" ] ; then
         echo 'Extension has not been uninstalled.'
         exit 1
     fi
+elif [ "${TYPE}" == "tar-uninstall" ] ; then
+    # shellcheck disable=SC1091
+    source /.scripts/before_uninstall
+    ## Verify if the elastic php agent has been uninstalled
+    php -m > /dev/null 2>&1
+    if php -m | grep -q 'elastic' ; then
+        echo 'Extension has not been uninstalled.'
+        exit 1
+    fi
 fi

--- a/packaging/test/ubuntu/entrypoint.sh
+++ b/packaging/test/ubuntu/entrypoint.sh
@@ -42,12 +42,12 @@ elif [ "${TYPE}" == "release-tar-github" ] ; then
     ## Install tar package and configure the agent accordingly
     tar -xf ${BUILD_RELEASES_FOLDER}/${PACKAGE} -C /
     # shellcheck disable=SC1091
-    source /.scripts/after_install
+    source /opt/elastic/apm-agent-php/bin/after_install
 else
     ## Install tar package and configure the agent accordingly
     tar -xf build/packages/*.tar -C /
     # shellcheck disable=SC1091
-    source /.scripts/after_install
+    source /opt/elastic/apm-agent-php/bin/post-install
 fi
 
 ## Verify if the elastic php agent is enabled
@@ -77,7 +77,7 @@ if [ "${TYPE}" == "deb-uninstall" ] ; then
     fi
 elif [ "${TYPE}" == "tar-uninstall" ] ; then
     # shellcheck disable=SC1091
-    source /.scripts/before_uninstall
+    source /opt/elastic/apm-agent-php/bin/before-uninstall
     ## Verify if the elastic php agent has been uninstalled
     php -m > /dev/null 2>&1
     if php -m | grep -q 'elastic' ; then


### PR DESCRIPTION
### What

As we have discussed the component tests are already executed as part of the package uninstall target, which it's in charge to:
- spin up a docker container
- install the agent
- run `composer run-script run_component_tests`
- uninstall the agent
- validate the uninstallation did not leave any leftovers


On the other hand, the `make -C packaging uninstall` goal is not called but the one specific for the distribution, this will avoid running the package-testing sequentially for each PHP version but all the PHP versions with all the supported distributions. 

### Why

This will help to run faster builds

### Actions

- [x] Enable tar-uninstall goal