### PR TITLE
🚧 [CI] Support PHP 8.rc

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
             axes {
               axis {
                 name 'PHP_VERSION'
-                values '7.2', '7.3', '7.4'
+                values '7.2', '7.3', '7.4', '8.0-rc'
               }
               axis {
                 name 'DOCKERFILE'
@@ -200,7 +200,7 @@ pipeline {
             axes {
               axis {
                 name 'PHP_VERSION'
-                values '7.2', '7.3', '7.4'
+                values '7.2', '7.3', '7.4', '8.0-rc'
               }
               axis {
                 name 'DIST'
@@ -300,7 +300,7 @@ pipeline {
             axes {
               axis {
                 name 'PHP_VERSION'
-                values '7.2', '7.3', '7.4'
+                values '7.2', '7.3', '7.4', '8.0-rc'
               }
             }
             stages {
@@ -357,7 +357,7 @@ pipeline {
             axes {
               axis {
                 name 'PHP_VERSION'
-                values '7.2', '7.3', '7.4'
+                values '7.2', '7.3', '7.4', '8.0-rc'
               }
             }
             stages {

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -18,6 +18,9 @@ CURRENT_GID := $(shell id -g)
 help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: all  ## Run all the target goals sequentially
+all: prepare build static-check-unit-test generate-for-package component-test
+
 .PHONY: prepare
 prepare:  ## Build docker image for building and testing the project
 	@docker build \

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -8,6 +8,7 @@ centos:centos7
 php:7.2-fpm
 php:7.3-fpm
 php:7.4-fpm
+php:8.0-rc-fpm
 ruby:2.7.1-alpine3.12
 "
 if [ -x "$(command -v docker)" ]; then
@@ -16,7 +17,7 @@ if [ -x "$(command -v docker)" ]; then
   (retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"
   done
 
-  for version in 7.2 7.3 7.4
+  for version in 7.2 7.3 7.4 8.0-rc
   do
     PHP_VERSION=${version} make -f .ci/Makefile prepare || true
     DOCKERFILE=Dockerfile.alpine PHP_VERSION=${version} make -f .ci/Makefile prepare || true


### PR DESCRIPTION
🚧 

### What

Use 8-rc for testing what changes might be required


### Why

Early access to the rc might help us to detect issues in advance


### Test

```bash
$ PHP_VERSION=8.0-rc make -f .ci/Makefile all
```