### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     ONLY_DOCS = "false"
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    OPBEANS_REPO = 'opbeans-php'
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
@@ -380,6 +381,25 @@ pipeline {
                   }
                 }
               }
+            }
+          }
+        }
+        stage('Opbeans') {
+          options {
+            skipDefaultCheckout()
+          }
+          environment {
+            REPO_NAME = "${OPBEANS_REPO}"
+          }
+          steps {
+            deleteDir()
+            dir("${OPBEANS_REPO}"){
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // The opbeans pipeline will trigger a release for the master branch
+              gitPush()
+              // The opbeans pipeline will trigger a release for the release tag with the format v<major>.<minor>.<patch>
+              gitCreateTag(tag: "${env.BRANCH_NAME}")
             }
           }
         }


### PR DESCRIPTION
### What

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:

- Bump dependency versions in the opbeans-php
- Push changes. (Implementation within the opbeans-php but the call it's done within this pipeline)
- Create a tag to trigger the release pipeline in the opbeans-php. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the master branch for the opbeans-php and tag it with the name of the tag version too. Therefore, the opbeans-php pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-php.

### Issues

Caused by https://github.com/elastic/opbeans-php/issues/1

