### PR TITLE
[packaging] detect php version during the installation

### DIFF
--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -192,9 +192,11 @@ function get_extension_file() {
 #### Function is_php_supported #################################################
 function is_php_supported() {
     PHP_MAJOR_MINOR=$(php_command -r 'echo PHP_MAJOR_VERSION;').$(php_command -r 'echo PHP_MINOR_VERSION;')
+    echo "Detected PHP version '${PHP_MAJOR_MINOR}'"
     if  [ "${PHP_MAJOR_MINOR}" == "7.2" ] || [ "${PHP_MAJOR_MINOR}" == "7.3" ] || [ "${PHP_MAJOR_MINOR}" == "7.4" ] ; then
         return 0
     else
+        echo 'Failed. The supported PHP versions are 7.2, 7.3 and 7.4.'
         return 1
     fi
 }

--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -189,12 +189,28 @@ function get_extension_file() {
 }
 
 ################################################################################
+#### Function is_php_supported #################################################
+function is_php_supported() {
+    PHP_MAJOR_MINOR=$(php_command -r 'echo PHP_MAJOR_VERSION;').$(php_command -r 'echo PHP_MINOR_VERSION;')
+    if  [ "${PHP_MAJOR_MINOR}" == "7.2" ] || [ "${PHP_MAJOR_MINOR}" == "7.3" ] || [ "${PHP_MAJOR_MINOR}" == "7.4" ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+################################################################################
 ############################### MAIN ###########################################
 ################################################################################
 echo 'Installing Elastic PHP agent'
 EXTENSION_FILE_PATH=$(get_extension_file)
 PHP_INI_FILE_PATH="$(php_ini_file_path)/php.ini"
 PHP_CONFIG_D_PATH="$(php_config_d_path)"
+
+if ! is_php_supported ; then
+    echo 'Failed. Elastic PHP agent extension is not supported for the existing PHP installation.'
+    exit 1
+fi
 
 if [ -e "${PHP_CONFIG_D_PATH}" ]; then
     install_conf_d_files "${PHP_CONFIG_D_PATH}"


### PR DESCRIPTION
### What

Add a PHP validation if the existing PHP installation is one of the supported versions. Otherwise, it will fail the installation.

### Why

Ensure we validate all the pre-requisites in advance before any installation

### Test

- For the happy path see the CI builds
- For a non-supported PHP installation then run the below commands locally:

```bash
$ make -f .ci/Makefile prepare build generate-for-package
...
$ make -C packaging prepare deb rpm tar
...
$ PHP_VERSION=7.1 make -C packaging deb-install rpm-install tar-install
...
Failed. Elastic PHP agent extension is not supported for the existing PHP installation.
dpkg: error processing package apm-agent-php (--install):
 installed apm-agent-php package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 apm-agent-php
make: *** [deb-install] Error 1

$ PHP_VERSION=7.1 make -C packaging rpm-install 
...
Installing Elastic PHP agent
Failed. Elastic PHP agent extension is not supported for the existing PHP installation.
warning: %post(apm-agent-php-1.0.0_beta1-1.noarch) scriptlet failed, exit status 1
+ validate_if_agent_is_enabled
+ php -m
+ grep -q elastic
Extension has not been installed.
+ echo 'Extension has not been installed.'
+ exit 1
make: *** [rpm-install] Error 1

$ PHP_VERSION=7.1 make -C packaging tar-install
...
++ echo 'Failed. Elastic PHP agent extension is not supported for the existing PHP installation.'
++ exit 1
make: *** [tar-install] Error 1
```

## Some alternatives

`fpm` provides a [`--depends`](https://github.com/jordansissel/fpm/wiki) flag but we don't want to enforce it as the PHP installation might be done in a different manner. 