### PR TITLE
[CI] reduce loop times since 60 takes 4 hours

### DIFF
--- a/.ci/loop.groovy
+++ b/.ci/loop.groovy
@@ -28,7 +28,7 @@ pipeline {
     cron('@midnight')
   }
   parameters {
-    string(name: 'LOOPS', defaultValue: '200', description: 'How many test loops?')
+    string(name: 'LOOPS', defaultValue: '60', description: 'How many test loops?')
   }
   stages {
     stage('Filter build') {


### PR DESCRIPTION
## What

For instance [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-php%2Fapm-agent-php-loop-mbp/detail/master/196/pipeline/169) took 5 hours and `[2021-02-02T07:25:30.355Z] Loop 61` was the last iteration.