### PR TITLE
docs: add boilerplate troubleshooting topic

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,7 @@ include::./public-api.asciidoc[]
 
 // include::./performance-tuning.asciidoc[]
 
-// include::./troubleshooting.asciidoc[]
+include::./troubleshooting.asciidoc[]
 
 // include::./upgrading.asciidoc[]
 

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -1,0 +1,14 @@
+[[troubleshooting]]
+== Troubleshooting
+
+Is something not working as expected?
+Don't worry if you can't figure out what the problem is; we’re here to help!
+As a first step, ensure your app is compatible with the agent's <<supported-technologies,supported technologies>>.
+
+If you're an existing Elastic customer with a support contract, please create a ticket in the
+https://support.elastic.co/customers/s/login/[Elastic Support portal].
+Other users can post in the https://discuss.elastic.co/c/apm[APM discuss forum].
+
+IMPORTANT: *Please upload your complete debug logs* to a service like https://gist.github.com[GitHub Gist]
+so that we can analyze the problem.
+Logs should include everything from when the application starts up until the first request executes.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -12,3 +12,22 @@ Other users can post in the https://discuss.elastic.co/c/apm[APM discuss forum].
 IMPORTANT: *Please upload your complete debug logs* to a service like https://gist.github.com[GitHub Gist]
 so that we can analyze the problem.
 Logs should include everything from when the application starts up until the first request executes.
+
+[float]
+[[disable-agent]]
+=== Disable the Agent
+
+In the unlikely event the agent causes disruptions to a production application,
+you can disable the agent while you troubleshoot.
+
+Disable the agent by setting <<config-enabled,`enabled`>> to `false`.
+You'll need to restart your application for the changes to apply.
+
+// ****This is the boilerplate disable text. Until dynamic config is supported, it's commented out.****
+// If you have access to <<dynamic-configuration,dynamic configuration>>,
+// you can disable the recording of events by setting <<config-recording,`recording`>> to `false`.
+// When changed at runtime from a supported source, there's no need to restart your application.
+
+// If that doesn't work, or you don't have access to dynamic configuration, you can disable the agent by setting
+// <<config-enabled,`enabled`>> to `false`.
+// You'll need to restart your application for the changes to apply.


### PR DESCRIPTION
## Summary

This PR adds a boilerplate troubleshooting topic that can be linked to from elsewhere in the docs. As we get an idea of what users are struggling with, we can begin to add topics to this page.

## Related

For https://github.com/elastic/observability-docs/issues/383.
For https://github.com/elastic/apm-server/pull/4740.