### PR TITLE
[ci] improve release notifications with earlier feedback and set the description

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
               setEnvVar('PRE_RELEASE_STAGE', 'true')
               notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
             }
-            whenTrue(params.VERSION?.trim()) {
+            whenTrue(params.VERSION?.trim() ? true : false) {
               script {
                 currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} release triggered."
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,6 +41,11 @@ pipeline {
               setEnvVar('PRE_RELEASE_STAGE', 'true')
               notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
             }
+            whenTrue(params.VERSION?.trim()) {
+              script {
+                currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} release triggered."
+              }
+            }
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
         stage('Checkout') {
           steps {
             whenTrue(isInternalCI() && isTag()) {
+              setEnvVar('PRE_RELEASE_STAGE', 'true')
               notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
             }
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
@@ -316,6 +317,7 @@ pipeline {
         stage('Notify') {
           options { skipDefaultCheckout() }
           steps {
+            setEnvVar('PRE_RELEASE_STAGE', 'false')
             notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
                          body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.\n Changes: ${env.TAG_NAME}")
             setEnvVar('RELEASE', askAndWait("You are about to release version ${env.TAG_NAME}. Do you wish to release it?"))
@@ -460,6 +462,11 @@ pipeline {
       // OTOH it avoids duplicated notifications
       whenFalse(isInternalCI()){
         notifyBuildResult(prComment: true, analyzeFlakey: true, jobName: getFlakyJobName(withBranch: 'master'))
+      }
+    }
+    failure {
+      whenTrue(isInternalCI() && env.PRE_RELEASE_STAGE == 'true') {
+        notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Pre-release steps failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
       }
     }
   }


### PR DESCRIPTION
### What

Add the `release` build description in the `apm-ci` for helping to visualise when a release was manually triggered.

Notify if something bad happened for a release and the notification was not send in the release stage yet.