### PR TITLE
changelog: fix duplicated entries

### DIFF
--- a/.ci/docker/gren/Dockerfile
+++ b/.ci/docker/gren/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update -qq -y \
   && apt-get install -qq -y --no-install-recommends git \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install github-release-notes@0.17.3 -g
+# Forced to use a previous version to group the releases by tags.
+# See https://github.com/github-tools/github-release-notes/issues/279
+RUN npm install github-release-notes@0.17.2 -g
 WORKDIR /app
 
 ENTRYPOINT [ "/app/.ci/docker/gren/entrypoint.sh" ]


### PR DESCRIPTION
### What

Pin the version for gren to 0.17.2

### Why

The latest version of gren (0.17.3) has a bug github-tools/github-release-notes#279. This includes all issues rather than just the ones since the last tag.

### Issues

See https://github.com/elastic/apm-agent-php/issues/405

