### PR TITLE
Add PHP 8.0 to supported versions

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -20,7 +20,7 @@ The agent supports Linux operating system.
 [[supported-php-versions]]
 === PHP versions
 
-The agent supports PHP versions 7.2-7.4.
+The agent supports PHP versions 7.2-8.0.
 
 [float]
 [[supported-web-frameworks]]


### PR DESCRIPTION
Updates the documentation to mention that PHP 8 is now supported as of v1.1