### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/span.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/span.json
@@ -111,8 +111,11 @@
               ],
               "properties": {
                 "name": {
-                  "description": "Name is the identifier for the destination service, e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq'",
-                  "type": "string",
+                  "description": "Name is the identifier for the destination service, e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq' ( DEPRECATED: this field will be removed in a future release",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "maxLength": 1024
                 },
                 "resource": {
@@ -121,15 +124,16 @@
                   "maxLength": 1024
                 },
                 "type": {
-                  "description": "Type of the destination service, e.g. db, elasticsearch. Should typically be the same as span.type.",
-                  "type": "string",
+                  "description": "Type of the destination service, e.g. db, elasticsearch. Should typically be the same as span.type. DEPRECATED: this field will be removed in a future release",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "maxLength": 1024
                 }
               },
               "required": [
-                "name",
-                "resource",
-                "type"
+                "resource"
               ]
             }
           }


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/7b86cb707 deprecate span destination name and type fields (https://github.com/elastic/apm-server/pull/5468)