### PR TITLE
Increase stage timeout to 2 hours

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     stage('Initializing'){
       options {
         skipDefaultCheckout()
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
       }
       stages {
         stage('Checkout') {


### PR DESCRIPTION
We're getting close to the timeout for this stage and I think we may [actually be hitting it in some cases](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-php%2Fapm-agent-php-mbp/detail/master/215/pipeline/1272).