### PR TITLE
Implemented more flexible API to manually pass distributed tracing data

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -572,7 +572,34 @@ If your service communicates over a different, unsupported protocol,
 you can manually propagate distributed tracing context from a sending service
 to a receiving service using the agent's API.
 
-If the 
-In the context of the sending service you must add
-Add the traceparent header to outgoing requests
-Sending services must add the traceparent header to outgoing requests.
+Distributed tracing data consists of multiple key-value pairs.
+For example for HTTP protocol these pairs are passed as request headers.
+
+At the sending service you must add key-value pairs to the outgoing request.
+Use `injectDistributedTracingHeaders()` API to get the distributed tracing data
+from the corresponding instance of <<api-span-interface>> or <<api-transaction-interface>>
+
+For example assuming the outgoing request is associated with `$span`  :
+[source,php]
+----
+$span->injectDistributedTracingHeaders(
+    function (string $headerName, string $headerValue) use ($myRequest): void {
+        $myRequest->addHeader($headerName, $headerValue);
+    }
+);
+----
+
+At the receiving service you must pass key-value pairs from the sending side to `ElasticApm::newTransaction` API.
+
+Example:
+[source,php]
+----
+$myTransaction = ElasticApm::newTransaction('my TX name', 'my TX type')
+    ->distributedTracingHeaderExtractor(
+        function (string $headerName) use ($myRequest): ?string {
+            return $myRequest->hasHeader($headerName)
+                ? $myRequest->getHeader($headerName)
+                : null;
+        }
+    )->begin();
+----

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -11,6 +11,7 @@ customize and manually create spans and transactions.
 * <<api-elasticapm-class>> - Public API entry point
 * <<api-transaction-interface>>
 * <<api-span-interface>>
+* <<api-manual-distributed-tracing>>
 
 [float]
 [[api-elasticapm-class]]
@@ -562,3 +563,16 @@ Example:
 ----
 $span->end();
 ----
+
+[float]
+[[api-manual-distributed-tracing]]
+=== Manual distributed tracing
+Elastic APM PHP agent automatically propagates distributed tracing context for <<supported-technologies,supported technologies>>.
+If your service communicates over a different, unsupported protocol,
+you can manually propagate distributed tracing context from a sending service
+to a receiving service using the agent's API.
+
+If the 
+In the context of the sending service you must add
+Add the traceparent header to outgoing requests
+Sending services must add the traceparent header to outgoing requests.

--- a/src/ElasticApm/DistributedTracingData.php
+++ b/src/ElasticApm/DistributedTracingData.php
@@ -38,8 +38,8 @@ final class DistributedTracingData
     public $isSampled;
 
     /**
-     * @deprecated Deprecated since version 1.3 - use ElasticApm::injectTraceHeaders() instead
-     * @see             injectTraceHeaders() Use it instead of this method
+     * @deprecated Deprecated since version 1.3 - use injectHeaders() instead
+     * @see             injectHeaders() Use it instead of this method
      *
      * Returns distributed tracing data for the current span/transaction
      */
@@ -49,15 +49,17 @@ final class DistributedTracingData
     }
 
     /**
-     * Returns distributed tracing data for the current span/transaction
+     * Gets distributed tracing data for the current span/transaction
      *
      * $headerInjector is callback to inject headers with signature
      *
      *      (string $headerName, string $headerValue): void
      *
      * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     *
+     * @phpstan-param Closure(string, string): void $headerInjector
      */
-    public function injectTraceHeaders(Closure $headerInjector): void
+    public function injectHeaders(Closure $headerInjector): void
     {
         $headerInjector(
             HttpDistributedTracing::TRACE_PARENT_HEADER_NAME,

--- a/src/ElasticApm/DistributedTracingData.php
+++ b/src/ElasticApm/DistributedTracingData.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Elastic\Apm;
 
+use Closure;
 use Elastic\Apm\Impl\HttpDistributedTracing;
 
 final class DistributedTracingData
@@ -36,8 +37,31 @@ final class DistributedTracingData
     /** @var bool */
     public $isSampled;
 
+    /**
+     * @deprecated Deprecated since version 1.3 - use ElasticApm::injectTraceHeaders() instead
+     * @see             injectTraceHeaders() Use it instead of this method
+     *
+     * Returns distributed tracing data for the current span/transaction
+     */
     public function serializeToString(): string
     {
         return HttpDistributedTracing::buildTraceParentHeader($this);
+    }
+
+    /**
+     * Returns distributed tracing data for the current span/transaction
+     *
+     * $headerInjector is callback to inject headers with signature
+     *
+     *      (string $headerName, string $headerValue): void
+     *
+     * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     */
+    public function injectTraceHeaders(Closure $headerInjector): void
+    {
+        $headerInjector(
+            HttpDistributedTracing::TRACE_PARENT_HEADER_NAME,
+            HttpDistributedTracing::buildTraceParentHeader($this)
+        );
     }
 }

--- a/src/ElasticApm/ElasticApm.php
+++ b/src/ElasticApm/ElasticApm.php
@@ -35,16 +35,16 @@ final class ElasticApm
 {
     use StaticClassTrait;
 
-    /** @var string */
     public const VERSION = '1.2';
 
     /**
      * Begins a new transaction and sets it as the current transaction.
      *
-     * @param string      $name      New transaction's name
-     * @param string      $type      New transaction's type
-     * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string      $name                      New transaction's name
+     * @param string      $type                      New transaction's type
+     * @param float|null  $timestamp                 Start time of the new transaction
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return TransactionInterface New transaction
      *
@@ -70,11 +70,15 @@ final class ElasticApm
      * @param string      $type      New transaction's type
      * @param Closure     $callback  Callback to execute as the new transaction
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return mixed The return value of $callback
      *
-     * @template        T
+     * @template T
+     * @phpstan-param Closure(TransactionInterface): T $callback Callback to execute as the new transaction
+     * @phpstan-return T The return value of $callback
+     *
      * @see             TransactionInterface::setName() For the description.
      * @see             TransactionInterface::setType() For the description.
      * @see             TransactionInterface::getTimestamp() For the description.
@@ -111,7 +115,8 @@ final class ElasticApm
      * @param string      $name      New transaction's name
      * @param string      $type      New transaction's type
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return TransactionInterface New transaction
      *
@@ -136,11 +141,15 @@ final class ElasticApm
      * @param string      $type      New transaction's type
      * @param Closure     $callback  Callback to execute as the new transaction
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return mixed The return value of $callback
      *
-     * @template        T
+     * @template T
+     * @phpstan-param Closure(TransactionInterface): T $callback Callback to execute as the new transaction
+     * @phpstan-return T The return value of $callback
+     *
      * @see             TransactionInterface::setName() For the description.
      * @see             TransactionInterface::setType() For the description.
      * @see             TransactionInterface::getTimestamp() For the description.
@@ -159,6 +168,23 @@ final class ElasticApm
             $timestamp,
             $serializedDistTracingData
         );
+    }
+
+    /**
+     * Advanced API to begin a new transaction
+     *
+     * @param string $name New transaction's name
+     * @param string $type New transaction's type
+     *
+     * @return TransactionBuilderInterface New transaction builder
+     *
+     * @see TransactionInterface::setName() For the description.
+     * @see TransactionInterface::setType() For the description.
+     *
+     */
+    public static function newTransaction(string $name, string $type): TransactionBuilderInterface
+    {
+        return GlobalTracerHolder::get()->newTransaction($name, $type);
     }
 
     /**
@@ -210,10 +236,28 @@ final class ElasticApm
     }
 
     /**
+     * @deprecated      Deprecated since version 1.3 - use injectDistributedTracingHeaders() instead
+     * @see             injectDistributedTracingHeaders() Use it instead of this method
+     *
      * Returns distributed tracing data for the current span/transaction
      */
     public static function getSerializedCurrentDistributedTracingData(): string
     {
+        /** @noinspection PhpDeprecationInspection */
         return GlobalTracerHolder::get()->getSerializedCurrentDistributedTracingData();
+    }
+
+    /**
+     * Returns distributed tracing data for the current span/transaction
+     *
+     * $headerInjector is callback to inject headers with signature
+     *
+     *      (string $headerName, string $headerValue): void
+     *
+     * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     */
+    public static function injectDistributedTracingHeaders(Closure $headerInjector): void
+    {
+        GlobalTracerHolder::get()->injectDistributedTracingHeaders($headerInjector);
     }
 }

--- a/src/ElasticApm/ElasticApm.php
+++ b/src/ElasticApm/ElasticApm.php
@@ -51,7 +51,6 @@ final class ElasticApm
      * @see TransactionInterface::setName() For the description.
      * @see TransactionInterface::setType() For the description.
      * @see TransactionInterface::getTimestamp() For the description.
-     *
      */
     public static function beginCurrentTransaction(
         string $name,
@@ -107,6 +106,18 @@ final class ElasticApm
     public static function getCurrentTransaction(): TransactionInterface
     {
         return GlobalTracerHolder::get()->getCurrentTransaction();
+    }
+
+    /**
+     * If there is the current span then it returns the current span.
+     * Otherwise if there is the current transaction then it returns the current transaction.
+     * Otherwise it returns the noop execution segment.
+     *
+     * @return ExecutionSegmentInterface The current execution segment
+     */
+    public static function getCurrentExecutionSegment(): ExecutionSegmentInterface
+    {
+        return GlobalTracerHolder::get()->getCurrentExecutionSegment();
     }
 
     /**
@@ -245,19 +256,5 @@ final class ElasticApm
     {
         /** @noinspection PhpDeprecationInspection */
         return GlobalTracerHolder::get()->getSerializedCurrentDistributedTracingData();
-    }
-
-    /**
-     * Returns distributed tracing data for the current span/transaction
-     *
-     * $headerInjector is callback to inject headers with signature
-     *
-     *      (string $headerName, string $headerValue): void
-     *
-     * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
-     */
-    public static function injectDistributedTracingHeaders(Closure $headerInjector): void
-    {
-        GlobalTracerHolder::get()->injectDistributedTracingHeaders($headerInjector);
     }
 }

--- a/src/ElasticApm/ExecutionSegmentInterface.php
+++ b/src/ElasticApm/ExecutionSegmentInterface.php
@@ -148,9 +148,23 @@ interface ExecutionSegmentInterface
     public function setType(string $type): void;
 
     /**
+     * @deprecated      Deprecated since version 1.3 - use injectTraceHeaders() instead
+     * @see             injectTraceHeaders() Use it instead of this method
+     *
      * Returns distributed tracing data
      */
     public function getDistributedTracingData(): ?DistributedTracingData;
+
+    /**
+     * Returns distributed tracing data for the current span/transaction
+     *
+     * $headerInjector is callback to inject headers with signature
+     *
+     *      (string $headerName, string $headerValue): void
+     *
+     * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void;
 
     /**
      * Sets the end timestamp and finalizes this object's state.

--- a/src/ElasticApm/ExecutionSegmentInterface.php
+++ b/src/ElasticApm/ExecutionSegmentInterface.php
@@ -148,8 +148,8 @@ interface ExecutionSegmentInterface
     public function setType(string $type): void;
 
     /**
-     * @deprecated      Deprecated since version 1.3 - use injectTraceHeaders() instead
-     * @see             injectTraceHeaders() Use it instead of this method
+     * @deprecated      Deprecated since version 1.3 - use injectDistributedTracingHeaders() instead
+     * @see             injectDistributedTracingHeaders() Use it instead of this method
      *
      * Returns distributed tracing data
      */
@@ -163,6 +163,8 @@ interface ExecutionSegmentInterface
      *      (string $headerName, string $headerValue): void
      *
      * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     *
+     * @phpstan-param Closure(string, string): void $headerInjector
      */
     public function injectDistributedTracingHeaders(Closure $headerInjector): void;
 

--- a/src/ElasticApm/Impl/ExecutionSegment.php
+++ b/src/ElasticApm/Impl/ExecutionSegment.php
@@ -284,7 +284,7 @@ abstract class ExecutionSegment implements ExecutionSegmentInterface, LoggableIn
         /** @noinspection PhpDeprecationInspection */
         $distTracingData = $this->getDistributedTracingData();
         if ($distTracingData !== null) {
-            $distTracingData->injectTraceHeaders($headerInjector);
+            $distTracingData->injectHeaders($headerInjector);
         }
     }
 

--- a/src/ElasticApm/Impl/ExecutionSegment.php
+++ b/src/ElasticApm/Impl/ExecutionSegment.php
@@ -278,6 +278,16 @@ abstract class ExecutionSegment implements ExecutionSegmentInterface, LoggableIn
         $this->data->type = Tracer::limitKeywordString($type);
     }
 
+    /** @inheritDoc */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void
+    {
+        /** @noinspection PhpDeprecationInspection */
+        $distTracingData = $this->getDistributedTracingData();
+        if ($distTracingData !== null) {
+            $distTracingData->injectTraceHeaders($headerInjector);
+        }
+    }
+
     public static function isValidOutcome(?string $outcome): bool
     {
         return $outcome === null

--- a/src/ElasticApm/Impl/NoopExecutionSegment.php
+++ b/src/ElasticApm/Impl/NoopExecutionSegment.php
@@ -121,6 +121,11 @@ abstract class NoopExecutionSegment implements ExecutionSegmentInterface, Loggab
     }
 
     /** @inheritDoc */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void
+    {
+    }
+
+    /** @inheritDoc */
     public function end(?float $duration = null): void
     {
     }

--- a/src/ElasticApm/Impl/NoopTracer.php
+++ b/src/ElasticApm/Impl/NoopTracer.php
@@ -25,6 +25,7 @@ namespace Elastic\Apm\Impl;
 
 use Closure;
 use Elastic\Apm\CustomErrorData;
+use Elastic\Apm\ExecutionSegmentInterface;
 use Elastic\Apm\Impl\Util\NoopObjectTrait;
 use Elastic\Apm\TransactionBuilderInterface;
 use Elastic\Apm\TransactionInterface;
@@ -62,6 +63,12 @@ final class NoopTracer implements TracerInterface
 
     /** @inheritDoc */
     public function getCurrentTransaction(): TransactionInterface
+    {
+        return NoopTransaction::singletonInstance();
+    }
+
+    /** @inheritDoc */
+    public function getCurrentExecutionSegment(): ExecutionSegmentInterface
     {
         return NoopTransaction::singletonInstance();
     }

--- a/src/ElasticApm/Impl/NoopTracer.php
+++ b/src/ElasticApm/Impl/NoopTracer.php
@@ -26,6 +26,7 @@ namespace Elastic\Apm\Impl;
 use Closure;
 use Elastic\Apm\CustomErrorData;
 use Elastic\Apm\Impl\Util\NoopObjectTrait;
+use Elastic\Apm\TransactionBuilderInterface;
 use Elastic\Apm\TransactionInterface;
 use Throwable;
 
@@ -87,6 +88,12 @@ final class NoopTracer implements TracerInterface
     }
 
     /** @inheritDoc */
+    public function newTransaction(string $name, string $type): TransactionBuilderInterface
+    {
+        return NoopTransactionBuilder::singletonInstance();
+    }
+
+    /** @inheritDoc */
     public function createErrorFromThrowable(Throwable $throwable): ?string
     {
         return null;
@@ -123,5 +130,10 @@ final class NoopTracer implements TracerInterface
     public function getSerializedCurrentDistributedTracingData(): string
     {
         return NoopDistributedTracingData::serializedToString();
+    }
+
+    /** @inheritDoc */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void
+    {
     }
 }

--- a/src/ElasticApm/Impl/NoopTransactionBuilder.php
+++ b/src/ElasticApm/Impl/NoopTransactionBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Impl;
+
+use Closure;
+use Elastic\Apm\Impl\Util\NoopObjectTrait;
+use Elastic\Apm\TransactionBuilderInterface;
+use Elastic\Apm\TransactionInterface;
+
+/**
+ * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
+ *
+ * @internal
+ */
+final class NoopTransactionBuilder implements TransactionBuilderInterface
+{
+    use NoopObjectTrait;
+
+    /** @inheritDoc */
+    public function asCurrent(): TransactionBuilderInterface
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function timestamp(float $timestamp): TransactionBuilderInterface
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function distributedTracingHeaderExtractor(Closure $headerExtractor): TransactionBuilderInterface
+    {
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function begin(): TransactionInterface
+    {
+        return NoopTransaction::singletonInstance();
+    }
+
+    /** @inheritDoc */
+    public function capture(Closure $callback)
+    {
+        return $callback(NoopTransaction::singletonInstance());
+    }
+}

--- a/src/ElasticApm/Impl/Tracer.php
+++ b/src/ElasticApm/Impl/Tracer.php
@@ -25,7 +25,6 @@ namespace Elastic\Apm\Impl;
 
 use Closure;
 use Elastic\Apm\CustomErrorData;
-use Elastic\Apm\DistributedTracingData;
 use Elastic\Apm\ElasticApm;
 use Elastic\Apm\Impl\BackendComm\EventSender;
 use Elastic\Apm\Impl\BreakdownMetrics\PerTransaction as BreakdownMetricsPerTransaction;
@@ -39,6 +38,7 @@ use Elastic\Apm\Impl\Log\LoggerFactory;
 use Elastic\Apm\Impl\Log\LogStreamInterface;
 use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 use Elastic\Apm\Impl\Util\TextUtil;
+use Elastic\Apm\TransactionBuilderInterface;
 use Elastic\Apm\TransactionInterface;
 use Throwable;
 
@@ -123,27 +123,16 @@ final class Tracer implements TracerInterface, LoggableInterface
         return $this->config;
     }
 
-    private function beginTransactionImpl(
+    private function newTransactionBuilder(
         string $name,
         string $type,
-        ?float $timestamp,
-        ?string $serializedDistTracingData
-    ): ?Transaction {
-        if (!$this->isRecording) {
-            return null;
-        }
-
-        $distributedTracingData = $serializedDistTracingData !== null
-            ? $this->unserializeDistributedTracingDataFromString($serializedDistTracingData)
-            : null;
-
-        return new Transaction($this, $name, $type, $timestamp, $distributedTracingData);
-    }
-
-    public function unserializeDistributedTracingDataFromString(
-        string $serializedDistTracingData
-    ): ?DistributedTracingData {
-        return $this->httpDistributedTracing->parseTraceParentHeader($serializedDistTracingData);
+        ?float $timestamp = null,
+        ?string $serializedDistTracingData = null
+    ): TransactionBuilder {
+        $builder = new TransactionBuilder($this, $name, $type);
+        $builder->timestamp = $timestamp;
+        $builder->serializedDistTracingData = $serializedDistTracingData;
+        return $builder;
     }
 
     /** @inheritDoc */
@@ -153,21 +142,9 @@ final class Tracer implements TracerInterface, LoggableInterface
         ?float $timestamp = null,
         ?string $serializedDistTracingData = null
     ): TransactionInterface {
-        if (!is_null($this->currentTransaction)) {
-            ($loggerProxy = $this->logger->ifWarningLevelEnabled(__LINE__, __FUNCTION__))
-            && $loggerProxy->log(
-                'Received request to begin a new current transaction'
-                . ' even though there is a current transaction that is still not ended',
-                ['this' => $this]
-            );
-        }
-
-        $this->currentTransaction = $this->beginTransactionImpl($name, $type, $timestamp, $serializedDistTracingData);
-        if (is_null($this->currentTransaction)) {
-            return NoopTransaction::singletonInstance();
-        }
-
-        return $this->currentTransaction;
+        $builder = $this->newTransactionBuilder($name, $type, $timestamp, $serializedDistTracingData);
+        $builder->asCurrent();
+        return $this->beginTransactionWithBuilder($builder);
     }
 
     /** @inheritDoc */
@@ -178,15 +155,9 @@ final class Tracer implements TracerInterface, LoggableInterface
         ?float $timestamp = null,
         ?string $serializedDistTracingData = null
     ) {
-        $newTransaction = $this->beginCurrentTransaction($name, $type, $timestamp, $serializedDistTracingData);
-        try {
-            return $callback($newTransaction);
-        } catch (Throwable $throwable) {
-            $newTransaction->createErrorFromThrowable($throwable);
-            throw $throwable;
-        } finally {
-            $newTransaction->end();
-        }
+        $builder = $this->newTransactionBuilder($name, $type, $timestamp, $serializedDistTracingData);
+        $builder->asCurrent();
+        return $this->captureTransactionWithBuilder($builder, $callback);
     }
 
     public function getCurrentTransaction(): TransactionInterface
@@ -206,13 +177,8 @@ final class Tracer implements TracerInterface, LoggableInterface
         ?float $timestamp = null,
         ?string $serializedDistTracingData = null
     ): TransactionInterface {
-        $newTransaction = $this->beginTransactionImpl($name, $type, $timestamp, $serializedDistTracingData);
-
-        if (is_null($newTransaction)) {
-            return NoopTransaction::singletonInstance();
-        }
-
-        return $newTransaction;
+        $builder = $this->newTransactionBuilder($name, $type, $timestamp, $serializedDistTracingData);
+        return $this->beginTransactionWithBuilder($builder);
     }
 
     /** @inheritDoc */
@@ -223,12 +189,57 @@ final class Tracer implements TracerInterface, LoggableInterface
         ?float $timestamp = null,
         ?string $serializedDistTracingData = null
     ) {
-        $newTransaction = $this->beginTransaction($name, $type, $timestamp, $serializedDistTracingData);
+        $builder = $this->newTransactionBuilder($name, $type, $timestamp, $serializedDistTracingData);
+        return $this->captureTransactionWithBuilder($builder, $callback);
+    }
+
+    /** @inheritDoc */
+    public function newTransaction(string $name, string $type): TransactionBuilderInterface
+    {
+        return new TransactionBuilder($this, $name, $type);
+    }
+
+    public function beginTransactionWithBuilder(TransactionBuilder $builder): TransactionInterface
+    {
+        if (!$this->isRecording) {
+            return NoopTransaction::singletonInstance();
+        }
+
+        $newTransaction = new Transaction($builder);
+
+        if ($builder->asCurrent) {
+            if ($this->currentTransaction !== null) {
+                ($loggerProxy = $this->logger->ifWarningLevelEnabled(__LINE__, __FUNCTION__))
+                && $loggerProxy->log(
+                    'Received request to begin a new current transaction'
+                    . ' even though there is a current transaction that is still not ended',
+                    ['this' => $this]
+                );
+            }
+
+            $this->currentTransaction = $newTransaction;
+        }
+
+        return $newTransaction;
+    }
+
+    /**
+     * @param TransactionBuilder                       $builder
+     * @param Closure                                  $callback
+     *
+     * @return mixed The return value of $callback
+     *
+     * @template T
+     * @phpstan-param Closure(TransactionInterface): T $callback Callback to execute as the new transaction
+     * @phpstan-return T The return value of $callback
+     */
+    public function captureTransactionWithBuilder(TransactionBuilder $builder, Closure $callback)
+    {
+        $newTransaction = $this->beginTransactionWithBuilder($builder);
         try {
             return $callback($newTransaction);
         } catch (Throwable $throwable) {
             $newTransaction->createErrorFromThrowable($throwable);
-            /** @noinspection PhpUnhandledExceptionInspection */
             throw $throwable;
         } finally {
             $newTransaction->end();
@@ -389,13 +400,29 @@ final class Tracer implements TracerInterface, LoggableInterface
     /** @inheritDoc */
     public function getSerializedCurrentDistributedTracingData(): string
     {
+        /** @noinspection PhpDeprecationInspection */
         $distTracingData = $this->currentTransaction !== null
             ? $this->currentTransaction->getDistributedTracingData()
             : null;
 
+        /** @noinspection PhpDeprecationInspection */
         return $distTracingData !== null
             ? $distTracingData->serializeToString()
             : NoopDistributedTracingData::serializedToString();
+    }
+
+    /** @inheritDoc */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void
+    {
+        if ($this->currentTransaction === null) {
+            return;
+        }
+
+        /** @noinspection PhpDeprecationInspection */
+        $distTracingData = $this->currentTransaction->getDistributedTracingData();
+        if ($distTracingData !== null) {
+            $distTracingData->injectTraceHeaders($headerInjector);
+        }
     }
 
     public function toLog(LogStreamInterface $stream): void

--- a/src/ElasticApm/Impl/Tracer.php
+++ b/src/ElasticApm/Impl/Tracer.php
@@ -26,6 +26,7 @@ namespace Elastic\Apm\Impl;
 use Closure;
 use Elastic\Apm\CustomErrorData;
 use Elastic\Apm\ElasticApm;
+use Elastic\Apm\ExecutionSegmentInterface;
 use Elastic\Apm\Impl\BackendComm\EventSender;
 use Elastic\Apm\Impl\BreakdownMetrics\PerTransaction as BreakdownMetricsPerTransaction;
 use Elastic\Apm\Impl\Config\Snapshot as ConfigSnapshot;
@@ -160,9 +161,20 @@ final class Tracer implements TracerInterface, LoggableInterface
         return $this->captureTransactionWithBuilder($builder, $callback);
     }
 
+    /** @inheritDoc */
     public function getCurrentTransaction(): TransactionInterface
     {
         return $this->currentTransaction ?? NoopTransaction::singletonInstance();
+    }
+
+    /** @inheritDoc */
+    public function getCurrentExecutionSegment(): ExecutionSegmentInterface
+    {
+        if ($this->currentTransaction === null) {
+            return NoopTransaction::singletonInstance();
+        }
+
+        return $this->currentTransaction->getCurrentExecutionSegment();
     }
 
     public function resetCurrentTransaction(): void
@@ -421,7 +433,7 @@ final class Tracer implements TracerInterface, LoggableInterface
         /** @noinspection PhpDeprecationInspection */
         $distTracingData = $this->currentTransaction->getDistributedTracingData();
         if ($distTracingData !== null) {
-            $distTracingData->injectTraceHeaders($headerInjector);
+            $distTracingData->injectHeaders($headerInjector);
         }
     }
 

--- a/src/ElasticApm/Impl/TracerInterface.php
+++ b/src/ElasticApm/Impl/TracerInterface.php
@@ -25,9 +25,9 @@ namespace Elastic\Apm\Impl;
 
 use Closure;
 use Elastic\Apm\CustomErrorData;
-use Elastic\Apm\DistributedTracingData;
 use Elastic\Apm\ElasticApm;
 use Elastic\Apm\TransactionInterface;
+use Elastic\Apm\TransactionBuilderInterface;
 use Throwable;
 
 interface TracerInterface
@@ -38,7 +38,8 @@ interface TracerInterface
      * @param string      $name      New transaction's name
      * @param string      $type      New transaction's type
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return TransactionInterface New transaction
      */
@@ -57,10 +58,10 @@ interface TracerInterface
      * @param string      $type      New transaction's type
      * @param Closure     $callback  Callback to execute as the new transaction
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return mixed The return value of $callback
-     * @template        T
      */
     public function captureCurrentTransaction(
         string $name,
@@ -81,7 +82,8 @@ interface TracerInterface
      * @param string      $name      New transaction's name
      * @param string      $type      New transaction's type
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return TransactionInterface New transaction
      */
@@ -100,10 +102,14 @@ interface TracerInterface
      * @param string      $type      New transaction's type
      * @param Closure     $callback  Callback to execute as the new transaction
      * @param float|null  $timestamp Start time of the new transaction
-     * @param string|null $serializedDistTracingData
+     * @param string|null $serializedDistTracingData - DEPRECATED since version 1.3 -
+     *                                               use newTransaction()->distributedTracingHeaderExtractor() instead
      *
      * @return mixed The return value of $callback
-     * @template        T
+     *
+     * @template T
+     * @phpstan-param Closure(TransactionInterface): T $callback Callback to execute as the new transaction
+     * @phpstan-return T The return value of $callback
      */
     public function captureTransaction(
         string $name,
@@ -112,6 +118,20 @@ interface TracerInterface
         ?float $timestamp = null,
         ?string $serializedDistTracingData = null
     );
+
+    /**
+     * Advanced API to begin a new transaction
+     *
+     * @param string $name New transaction's name
+     * @param string $type New transaction's type
+     *
+     * @return TransactionBuilderInterface New transaction builder
+     *
+     * @see TransactionInterface::setName() For the description.
+     * @see TransactionInterface::setType() For the description.
+     *
+     */
+    public function newTransaction(string $name, string $type): TransactionBuilderInterface;
 
     /**
      * Reports error event based on the given
@@ -163,7 +183,21 @@ interface TracerInterface
     public function setAgentEphemeralId(?string $ephemeralId): void;
 
     /**
+     * @deprecated      Deprecated since version 1.3 - use injectDistributedTracingHeaders() instead
+     * @see             injectDistributedTracingHeaders() Use it instead of this method
+     *
      * Returns distributed tracing data for the current span/transaction
      */
     public function getSerializedCurrentDistributedTracingData(): string;
+
+    /**
+     * Returns distributed tracing data for the current span/transaction
+     *
+     * $headerInjector is callback to inject headers with signature
+     *
+     *      (string $headerName, string $headerValue): void
+     *
+     * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     */
+    public function injectDistributedTracingHeaders(Closure $headerInjector): void;
 }

--- a/src/ElasticApm/Impl/TracerInterface.php
+++ b/src/ElasticApm/Impl/TracerInterface.php
@@ -26,6 +26,7 @@ namespace Elastic\Apm\Impl;
 use Closure;
 use Elastic\Apm\CustomErrorData;
 use Elastic\Apm\ElasticApm;
+use Elastic\Apm\ExecutionSegmentInterface;
 use Elastic\Apm\TransactionInterface;
 use Elastic\Apm\TransactionBuilderInterface;
 use Throwable;
@@ -75,6 +76,8 @@ interface TracerInterface
      * @see ElasticApm::getCurrentTransaction()
      */
     public function getCurrentTransaction(): TransactionInterface;
+
+    public function getCurrentExecutionSegment(): ExecutionSegmentInterface;
 
     /**
      * Begins a new transaction.
@@ -198,6 +201,8 @@ interface TracerInterface
      *      (string $headerName, string $headerValue): void
      *
      * @param Closure $headerInjector Callback that actually injects header(s) for the underlying transport
+     *
+     * @phpstan-param Closure(string, string): void $headerInjector
      */
     public function injectDistributedTracingHeaders(Closure $headerInjector): void;
 }

--- a/src/ElasticApm/Impl/Transaction.php
+++ b/src/ElasticApm/Impl/Transaction.php
@@ -25,6 +25,7 @@ namespace Elastic\Apm\Impl;
 
 use Closure;
 use Elastic\Apm\DistributedTracingData;
+use Elastic\Apm\ExecutionSegmentInterface;
 use Elastic\Apm\Impl\BreakdownMetrics\PerTransaction as BreakdownMetricsPerTransaction;
 use Elastic\Apm\Impl\Config\OptionNames;
 use Elastic\Apm\Impl\Config\Snapshot as ConfigSnapshot;
@@ -220,6 +221,11 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
     public function getCurrentSpan(): SpanInterface
     {
         return $this->currentSpan ?? NoopSpan::singletonInstance();
+    }
+
+    public function getCurrentExecutionSegment(): ExecutionSegmentInterface
+    {
+        return $this->currentSpan ?? $this;
     }
 
     public function setCurrentSpan(?Span $newCurrentSpan): void

--- a/src/ElasticApm/Impl/Transaction.php
+++ b/src/ElasticApm/Impl/Transaction.php
@@ -73,18 +73,14 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
     /** @var BreakdownMetricsPerTransaction */
     private $breakdownMetricsPerTransaction;
 
-    public function __construct(
-        Tracer $tracer,
-        string $name,
-        string $type,
-        ?float $timestamp = null,
-        ?DistributedTracingData $distributedTracingData = null
-    ) {
-        $this->tracer = $tracer;
+    public function __construct(TransactionBuilder $builder)
+    {
+        $this->tracer = $builder->tracer;
         $this->data = new TransactionData();
         $this->breakdownMetricsPerTransaction
-            = new BreakdownMetricsPerTransaction($this, $tracer->getConfig()->breakdownMetrics());
+            = new BreakdownMetricsPerTransaction($this, $builder->tracer->getConfig()->breakdownMetrics());
 
+        $distributedTracingData = self::extractDistributedTracingData($builder);
         if ($distributedTracingData == null) {
             $traceId = IdGenerator::generateId(Constants::TRACE_ID_SIZE_IN_BYTES);
         } else {
@@ -94,15 +90,15 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
 
         parent::__construct(
             $this->data,
-            $tracer,
+            $builder->tracer,
             null /* <- parentExecutionSegment */,
             $traceId,
-            $name,
-            $type,
-            $timestamp
+            $builder->name,
+            $builder->type,
+            $builder->timestamp
         );
 
-        $this->config = $tracer->getConfig();
+        $this->config = $builder->tracer->getConfig();
 
         $this->logger = $this->tracer->loggerFactory()
                                      ->loggerForClass(LogCategory::PUBLIC_API, __NAMESPACE__, __CLASS__, __FILE__)
@@ -114,6 +110,30 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Transaction created');
+    }
+
+    public static function extractDistributedTracingData(TransactionBuilder $builder): ?DistributedTracingData
+    {
+        $traceParentHeaderValue = null;
+        if ($builder->serializedDistTracingData === null) {
+            if ($builder->headersExtractor !== null) {
+                $traceParentHeaderValues
+                    = ($builder->headersExtractor)(HttpDistributedTracing::TRACE_PARENT_HEADER_NAME);
+                if (is_string($traceParentHeaderValues)) {
+                    $traceParentHeaderValue = $traceParentHeaderValues;
+                } elseif (is_array($traceParentHeaderValues) && count($traceParentHeaderValues) === 1) {
+                    $traceParentHeaderValue = $traceParentHeaderValues[0];
+                } else {
+                    return null;
+                }
+            }
+        } else {
+            $traceParentHeaderValue = $builder->serializedDistTracingData;
+        }
+
+        return $traceParentHeaderValue === null
+            ? null
+            : $builder->tracer->httpDistributedTracing()->parseTraceParentHeader($traceParentHeaderValue);
     }
 
     /** @inheritDoc */
@@ -367,6 +387,7 @@ final class Transaction extends ExecutionSegment implements TransactionInterface
             return $this->doGetDistributedTracingData(/* span */ null);
         }
 
+        /** @noinspection PhpDeprecationInspection */
         return $this->currentSpan->getDistributedTracingData();
     }
 

--- a/src/ElasticApm/Impl/TransactionBuilder.php
+++ b/src/ElasticApm/Impl/TransactionBuilder.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Impl;
+
+use Closure;
+use Elastic\Apm\TransactionBuilderInterface;
+use Elastic\Apm\TransactionInterface;
+
+/**
+ * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
+ *
+ * @internal
+ */
+final class TransactionBuilder implements TransactionBuilderInterface
+{
+    /** @var Tracer */
+    public $tracer;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $type;
+
+    /** @var bool */
+    public $asCurrent = false;
+
+    /** @var ?float */
+    public $timestamp = null;
+
+    /** @var ?Closure(string $headerName): null|string|string[] */
+    public $headersExtractor = null;
+
+    /** @var ?string */
+    public $serializedDistTracingData = null;
+
+    public function __construct(Tracer $tracer, string $name, string $type)
+    {
+        $this->tracer = $tracer;
+        $this->name = $name;
+        $this->type = $type;
+    }
+
+    /** @inheritDoc */
+    public function asCurrent(): TransactionBuilderInterface
+    {
+        $this->asCurrent = true;
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function timestamp(float $timestamp): TransactionBuilderInterface
+    {
+        $this->timestamp = $timestamp;
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function distributedTracingHeaderExtractor(Closure $headerExtractor): TransactionBuilderInterface
+    {
+        $this->headersExtractor = $headerExtractor;
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function begin(): TransactionInterface
+    {
+        return $this->tracer->beginTransactionWithBuilder($this);
+    }
+
+    /** @inheritDoc */
+    public function capture(Closure $callback)
+    {
+        return $this->tracer->captureTransactionWithBuilder($this, $callback);
+    }
+}

--- a/src/ElasticApm/TransactionBuilderInterface.php
+++ b/src/ElasticApm/TransactionBuilderInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Elastic\Apm;
+
+use Closure;
+
+/**
+ * Class to gather optional parameters to start a new transaction
+ *
+ * @see             ElasticApm::beginCurrentTransaction()
+ * @see             ElasticApm::captureCurrentTransaction()
+ */
+interface TransactionBuilderInterface
+{
+    /**
+     * New transaction will be set as the current one
+     *
+     * @return TransactionBuilderInterface
+     */
+    public function asCurrent(): self;
+
+    /**
+     * Set start time of the new transaction
+     *
+     * @param float $timestamp
+     *
+     * @return TransactionBuilderInterface
+     */
+    public function timestamp(float $timestamp): self;
+
+    /**
+     * @param Closure $headerExtractor
+     *
+     * @return TransactionBuilderInterface
+     *
+     * @phpstan-param Closure(string $headerName): (null|string|string[]) $headerExtractor
+     */
+    public function distributedTracingHeaderExtractor(Closure $headerExtractor): self;
+
+    /**
+     * Begins a new transaction.
+     *
+     * @return TransactionInterface New transaction
+     */
+    public function begin(): TransactionInterface;
+
+    /**
+     * Begins a new transaction,
+     * runs the provided callback as the new transaction and automatically ends the new transaction.
+     *
+     * @param Closure $callback
+     *
+     * @return mixed The return value of $callback
+     *
+     * @template T
+     * @phpstan-param Closure(TransactionInterface): T $callback Callback to execute as the new transaction
+     * @phpstan-return T The return value of $callback
+     */
+    public function capture(Closure $callback);
+}

--- a/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/StatefulHttpServerProcessBase.php
@@ -221,7 +221,7 @@ abstract class StatefulHttpServerProcessBase extends SpawnedProcessBase
         if (empty($headerValues)) {
             return null;
         }
-        if (count($headerValues) != 1) {
+        if (count($headerValues) !== 1) {
             throw new RuntimeException(
                 ExceptionUtil::buildMessage(
                     'The header should not have more than one value',

--- a/tests/ElasticApmTests/UnitTests/DistributedTracingTest.php
+++ b/tests/ElasticApmTests/UnitTests/DistributedTracingTest.php
@@ -210,7 +210,7 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
             $senderDistTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
         } else {
             $senderDistTracingData = [];
-            ElasticApm::injectDistributedTracingHeaders(
+            ElasticApm::getCurrentExecutionSegment()->injectDistributedTracingHeaders(
                 function (string $headerName, string $headerValue) use (&$senderDistTracingData): void {
                     $senderDistTracingData[$headerName] = $headerValue;
                 }
@@ -318,7 +318,7 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
             self::assertIsString($senderDistTracingData);
         } else {
             $senderDistTracingData = [];
-            ElasticApm::injectDistributedTracingHeaders(
+            ElasticApm::getCurrentExecutionSegment()->injectDistributedTracingHeaders(
                 function (string $headerName, string $headerValue) use (&$senderDistTracingData): void {
                     $senderDistTracingData[$headerName] = $headerValue;
                 }
@@ -544,7 +544,7 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
         if ($doesTxHaveParentAlready) {
             GlobalTracerHolder::set($webFrontTracer);
             $webFrontTx = ElasticApm::beginCurrentTransaction('web front end TX', 'web front end TX type');
-            ElasticApm::injectDistributedTracingHeaders(
+            ElasticApm::getCurrentExecutionSegment()->injectDistributedTracingHeaders(
                 function (string $headerName, string $headerValue) use (&$distTracingData): void {
                     $distTracingData[$headerName] = $headerValue;
                 }

--- a/tests/ElasticApmTests/UnitTests/DistributedTracingTest.php
+++ b/tests/ElasticApmTests/UnitTests/DistributedTracingTest.php
@@ -38,12 +38,164 @@ use ElasticApmTests\UnitTests\Util\TracerUnitTestCaseBase;
 class DistributedTracingTest extends TracerUnitTestCaseBase
 {
     /**
-     * @dataProvider boolDataProvider
+     * @param string                            $api
+     * @param bool                              $shouldUseDeprecatedApi
+     * @param bool                              $shouldReturnHeaderValueAsArray
+     * @param string                            $name
+     * @param string                            $type
+     * @param array<string, string>|string|null $distTracingData
      *
-     * @param bool $isSentFromSpan
+     * @return TransactionInterface
+     *
+     * @noinspection PhpSameParameterValueInspection
      */
-    public function testManualPassDistTracingData(bool $isSentFromSpan): void
+    private function beginAndEndTransactionUsingApi(
+        string $api,
+        bool $shouldUseDeprecatedApi,
+        bool $shouldReturnHeaderValueAsArray,
+        string $name,
+        string $type,
+        $distTracingData
+    ): TransactionInterface {
+        /** @var ?string */
+        $serializedDistTracingData = null;
+        /** @var ?array<string, string> */
+        $distTracingHeaders = null;
+        if ($distTracingData !== null && $shouldUseDeprecatedApi) {
+            self::assertIsString($distTracingData);
+            $serializedDistTracingData = $distTracingData;
+        } else {
+            self::assertIsArray($distTracingData);
+            $distTracingHeaders = $distTracingData;
+        }
+
+        $headerExtractor
+            = /**
+         * @param string $headerName
+         *
+         * @return string[]|string
+         */
+            function (string $headerName) use (
+                $distTracingHeaders,
+                $shouldReturnHeaderValueAsArray
+            ) {
+                self::assertNotNull($distTracingHeaders);
+                if (!array_key_exists($headerName, $distTracingHeaders)) {
+                    return [];
+                }
+                $headerValue = $distTracingHeaders[$headerName];
+                return $shouldReturnHeaderValueAsArray ? [$headerValue] : $headerValue;
+            };
+
+        $txBody = function (TransactionInterface $tx): TransactionInterface {
+            return $tx;
+        };
+
+        switch ($api) {
+            case 'beginCurrentTransaction':
+                $tx = $shouldUseDeprecatedApi
+                    ? ElasticApm::beginCurrentTransaction(
+                        $name,
+                        $type,
+                        null /* <- timestamp */,
+                        $serializedDistTracingData
+                    )
+                    : ElasticApm::newTransaction($name, $type)
+                                ->asCurrent()
+                                ->distributedTracingHeaderExtractor($headerExtractor)
+                                ->begin();
+                $tx->end();
+                return $tx;
+
+            case 'captureCurrentTransaction':
+                return $shouldUseDeprecatedApi
+                    ? ElasticApm::captureCurrentTransaction(
+                        $name,
+                        $type,
+                        $txBody,
+                        null /* <- timestamp */,
+                        $serializedDistTracingData
+                    )
+                    : ElasticApm::newTransaction($name, $type)
+                                ->asCurrent()
+                                ->distributedTracingHeaderExtractor($headerExtractor)
+                                ->capture($txBody);
+
+            case 'beginTransaction':
+                $tx = $shouldUseDeprecatedApi
+                    ? ElasticApm::beginTransaction(
+                        $name,
+                        $type,
+                        null /* <- timestamp */,
+                        $serializedDistTracingData
+                    )
+                    : ElasticApm::newTransaction($name, $type)
+                                ->distributedTracingHeaderExtractor($headerExtractor)
+                                ->begin();
+                $tx->end();
+                return $tx;
+
+            case 'captureTransaction':
+                return $shouldUseDeprecatedApi
+                    ? ElasticApm::captureTransaction(
+                        $name,
+                        $type,
+                        $txBody,
+                        null /* <- timestamp */,
+                        $serializedDistTracingData
+                    )
+                    : ElasticApm::newTransaction($name, $type)
+                                ->distributedTracingHeaderExtractor($headerExtractor)
+                                ->capture($txBody);
+
+            default:
+                self::fail('Unknown $api: ' . $api);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function beginTransactionApis(): array
     {
+        return ['beginCurrentTransaction', 'captureCurrentTransaction', 'beginTransaction', 'captureTransaction'];
+    }
+
+    /**
+     * @return iterable<array{bool, bool, bool, string}>
+     */
+    public function dataProviderForTestManualPassDistTracingData(): iterable
+    {
+        foreach ([false, true] as $isSentFromSpan) {
+            foreach ([false, true] as $shouldUseDeprecatedApi) {
+                foreach ([false, true] as $shouldReturnHeaderValueAsArray) {
+                    foreach (self::beginTransactionApis() as $beginTransactionApi) {
+                        yield [
+                            $isSentFromSpan,
+                            $shouldUseDeprecatedApi,
+                            $shouldReturnHeaderValueAsArray,
+                            $beginTransactionApi,
+                        ];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @dataProvider dataProviderForTestManualPassDistTracingData
+     *
+     * @param bool   $isSentFromSpan
+     * @param bool   $shouldUseDeprecatedApi
+     * @param bool   $shouldReturnHeaderValueAsArray
+     * @param string $beginTransactionApi
+     */
+    public function testManualPassDistTracingData(
+        bool $isSentFromSpan,
+        bool $shouldUseDeprecatedApi,
+        bool $shouldReturnHeaderValueAsArray,
+        string $beginTransactionApi
+    ): void {
         // Arrange
         // Act
 
@@ -53,16 +205,28 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
         }
 
         // On the sending side: get and serialize DistributedTracingData for the current span/transaction
-        $senderDistTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
+        if ($shouldUseDeprecatedApi) {
+            /** @noinspection PhpDeprecationInspection */
+            $senderDistTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
+        } else {
+            $senderDistTracingData = [];
+            ElasticApm::injectDistributedTracingHeaders(
+                function (string $headerName, string $headerValue) use (&$senderDistTracingData): void {
+                    $senderDistTracingData[$headerName] = $headerValue;
+                }
+            );
+        }
 
         // Pass DistributedTracingData to the receivinging side
         $receiverDistTracingData = $senderDistTracingData;
 
         // On the receivinging side
-        $receiverTransaction = ElasticApm::beginCurrentTransaction(
-            'GET /data-api',
-            'data-layer',
-            /* timestamp */ null,
+        $receiverTransaction = self::beginAndEndTransactionUsingApi(
+            $beginTransactionApi,
+            $shouldUseDeprecatedApi,
+            $shouldReturnHeaderValueAsArray,
+            'GET /data-api' /* <- name */,
+            'data-layer' /* <- type */,
             $receiverDistTracingData
         );
         self::assertSame($senderTransaction->getTraceId(), $receiverTransaction->getTraceId());
@@ -77,36 +241,54 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
 
         // Assert
 
-        $actualTxIds = array_keys($this->mockEventSink->idToTransaction());
-        self::assertTrue(sort(/* ref */ $actualTxIds));
-        self::assertCount(2, $actualTxIds);
         $expectedTxIds = [$senderTransaction->getId(), $receiverTransaction->getId()];
-        self::assertTrue(sort(/* ref */ $expectedTxIds));
-        self::assertEqualsCanonicalizing($expectedTxIds, $actualTxIds);
+        $actualTxIds = array_keys($this->mockEventSink->idToTransaction());
+        self::assertCount(2, $actualTxIds);
+        self::assertEqualLists($expectedTxIds, $actualTxIds);
         $idToSpan = $this->mockEventSink->idToSpan();
         self::assertCount($isSentFromSpan ? 1 : 0, $idToSpan);
         $expectedParentId = $isSentFromSpan ? $senderSpan->getId() : $senderTransaction->getId();
         self::assertSame($expectedParentId, $receiverTransaction->getParentId());
     }
 
-    public function testManualPassDistTracingDataTracerDisabled(): void
+    /**
+     * @return iterable<array{bool, bool, bool, string}>
+     */
+    public function dataProviderForTestManualPassDistTracingDataTracerDisabled(): iterable
     {
         foreach ([false, true] as $isSenderTracerEnabled) {
             foreach ([false, true] as $isReceiverTracerEnabled) {
-                foreach ([0, 1, 2] as $distDataSource) {
-                    $this->implManualPassDistTracingDataTracerDisabled(
-                        $isSenderTracerEnabled,
-                        $isReceiverTracerEnabled,
-                        $distDataSource
-                    );
+                foreach ([false, true] as $shouldUseDeprecatedApi) {
+                    foreach (self::beginTransactionApis() as $beginTransactionApi) {
+                        foreach ([0, 1, 2] as $distDataSource) {
+                            yield [
+                                $isSenderTracerEnabled,
+                                $isReceiverTracerEnabled,
+                                $shouldUseDeprecatedApi,
+                                $beginTransactionApi,
+                                $distDataSource,
+                            ];
+                        }
+                    }
                 }
             }
         }
     }
 
-    public function implManualPassDistTracingDataTracerDisabled(
+    /**
+     * @dataProvider dataProviderForTestManualPassDistTracingDataTracerDisabled
+     *
+     * @param bool   $isSenderTracerEnabled
+     * @param bool   $isReceiverTracerEnabled
+     * @param bool   $shouldUseDeprecatedApi
+     * @param string $beginTransactionApi
+     * @param int    $distDataSource
+     */
+    public function testManualPassDistTracingDataTracerDisabled(
         bool $isSenderTracerEnabled,
         bool $isReceiverTracerEnabled,
+        bool $shouldUseDeprecatedApi,
+        string $beginTransactionApi,
         int $distDataSource
     ): void {
         // Arrange
@@ -123,14 +305,25 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
 
         if ($distDataSource !== 0) {
             $senderTransaction = ElasticApm::beginCurrentTransaction('POST /web-layer-api', 'web-layer');
+            self::assertSame(!$senderTransaction->isNoop(), $isSenderTracerEnabled);
             if ($distDataSource !== 1) {
                 $senderSpan = $senderTransaction->beginCurrentSpan('fetch from data layer', 'data-layer');
             }
         }
 
         // On the sending side: get and serialize DistributedTracingData for the current span/transaction
-        $senderDistTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
-        self::assertIsString($senderDistTracingData);
+        if ($shouldUseDeprecatedApi) {
+            /** @noinspection PhpDeprecationInspection */
+            $senderDistTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
+            self::assertIsString($senderDistTracingData);
+        } else {
+            $senderDistTracingData = [];
+            ElasticApm::injectDistributedTracingHeaders(
+                function (string $headerName, string $headerValue) use (&$senderDistTracingData): void {
+                    $senderDistTracingData[$headerName] = $headerValue;
+                }
+            );
+        }
 
         // Pass DistributedTracingData to the receivinging side
         $receiverDistTracingData = $senderDistTracingData;
@@ -139,12 +332,18 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
         GlobalTracerHolder::set($receiverTracer);
 
         // On the receivinging side: begin a new transaction and pass received DistributedTracingData
-        $receiverTransaction = ElasticApm::beginCurrentTransaction(
-            'GET /data-api',
-            'data-layer',
-            /* timestamp */ null,
+        $receiverTransaction = self::beginAndEndTransactionUsingApi(
+            $beginTransactionApi,
+            $shouldUseDeprecatedApi,
+            false /* <- shouldReturnHeaderValueAsArray */,
+            'GET /data-api' /* <- name */,
+            'data-layer' /* <- type */,
             $receiverDistTracingData
         );
+        self::assertSame(!$receiverTransaction->isNoop(), $isReceiverTracerEnabled);
+        if (isset($senderTransaction) && ($isSenderTracerEnabled === $isReceiverTracerEnabled)) {
+            self::assertSame($senderTransaction->getTraceId(), $receiverTransaction->getTraceId());
+        }
 
         $receiverTransaction->end();
 
@@ -198,19 +397,129 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
         }
     }
 
-    public function testEnsureParentId(): void
+    public function testManualPassDistTracingDataConcurrentTransactionsAndSpans(): void
+    {
+        // Arrange
+
+        $senderEventSink = new MockEventSink();
+        $senderTracer = self::buildTracerForTests($senderEventSink)->build();
+        $receiverEventSink = new MockEventSink();
+        $receiverTracer = self::buildTracerForTests($receiverEventSink)->build();
+
+        // Act
+
+        // On the sending side:
+        GlobalTracerHolder::set($senderTracer);
+
+        $senderTxA = ElasticApm::beginTransaction('POST /web-layer-api-A', 'web-layer');
+        self::assertFalse($senderTxA->isNoop());
+        self::assertTrue(ElasticApm::getCurrentTransaction()->isNoop());
+        $senderTxB = ElasticApm::beginTransaction('POST /web-layer-api-B', 'web-layer');
+        self::assertFalse($senderTxB->isNoop());
+        self::assertTrue(ElasticApm::getCurrentTransaction()->isNoop());
+
+        $senderSpanB = $senderTxB->beginChildSpan('fetch from data layer B', 'data-layer');
+        self::assertFalse($senderSpanB->isNoop());
+        self::assertTrue($senderTxB->getCurrentSpan()->isNoop());
+        $senderSpanA = $senderTxA->beginChildSpan('fetch from data layer A', 'data-layer');
+        self::assertFalse($senderSpanA->isNoop());
+        self::assertTrue($senderTxA->getCurrentSpan()->isNoop());
+
+        $distTracingDataA = [];
+        $senderSpanA->injectDistributedTracingHeaders(
+            function (string $headerName, string $headerValue) use (&$distTracingDataA): void {
+                $distTracingDataA[$headerName] = $headerValue;
+            }
+        );
+
+        $distTracingDataB = [];
+        $senderSpanB->injectDistributedTracingHeaders(
+            function (string $headerName, string $headerValue) use (&$distTracingDataB): void {
+                $distTracingDataB[$headerName] = $headerValue;
+            }
+        );
+
+        // On the receivinging side
+        GlobalTracerHolder::set($receiverTracer);
+
+        $headerExtractorB = function (string $headerName) use ($distTracingDataB): ?string {
+            return array_key_exists($headerName, $distTracingDataB)
+                ? $distTracingDataB[$headerName]
+                : null;
+        };
+        $receiverTxB = ElasticApm::newTransaction('GET /data-api-B', 'data-layer')
+                                 ->distributedTracingHeaderExtractor($headerExtractorB)
+                                 ->begin();
+        self::assertFalse($receiverTxB->isNoop());
+        self::assertTrue(ElasticApm::getCurrentTransaction()->isNoop());
+
+
+        $headerExtractorA = function (string $headerName) use ($distTracingDataA): ?string {
+            return array_key_exists($headerName, $distTracingDataA)
+                ? $distTracingDataA[$headerName]
+                : null;
+        };
+        $receiverTxA = ElasticApm::newTransaction('GET /data-api-A', 'data-layer')
+                                 ->distributedTracingHeaderExtractor($headerExtractorA)
+                                 ->begin();
+        self::assertFalse($receiverTxA->isNoop());
+        self::assertTrue(ElasticApm::getCurrentTransaction()->isNoop());
+
+        $receiverTxB->end();
+        $receiverTxA->end();
+
+        GlobalTracerHolder::set($senderTracer);
+
+        $senderSpanB->end();
+        $senderSpanA->end();
+        $senderTxA->end();
+        $senderTxB->end();
+
+        // Assert
+
+        self::assertEmpty($this->mockEventSink->idToTransaction());
+        self::assertEmpty($this->mockEventSink->idToSpan());
+
+        $expectedSenderTxIds = [$senderTxA->getId(), $senderTxB->getId()];
+        self::assertEqualLists($expectedSenderTxIds, array_keys($senderEventSink->idToTransaction()));
+        $expectedSenderSpanIds = [$senderSpanA->getId(), $senderSpanB->getId()];
+        self::assertEqualLists($expectedSenderSpanIds, array_keys($senderEventSink->idToSpan()));
+        $expectedReceiverTxIds = [$receiverTxA->getId(), $receiverTxB->getId()];
+        self::assertEqualLists($expectedReceiverTxIds, array_keys($receiverEventSink->idToTransaction()));
+
+        $senderSpanAData = $senderEventSink->idToSpan()[$senderSpanA->getId()];
+        $receiverTxAData = $receiverEventSink->idToTransaction()[$receiverTxA->getId()];
+        self::assertSame($senderSpanAData->id, $receiverTxAData->parentId);
+        self::assertSame($senderSpanAData->traceId, $receiverTxAData->traceId);
+
+        $senderSpanBData = $senderEventSink->idToSpan()[$senderSpanB->getId()];
+        $receiverTxBData = $receiverEventSink->idToTransaction()[$receiverTxB->getId()];
+        self::assertSame($senderSpanBData->id, $receiverTxBData->parentId);
+        self::assertSame($senderSpanBData->traceId, $receiverTxBData->traceId);
+    }
+
+    /**
+     * @return iterable<array{bool, bool}>
+     */
+    public function dataPrividerForTestEnsureParentId(): iterable
     {
         foreach ([false, true] as $isTracerEnabled) {
             foreach ([false, true] as $doesTxHaveParentAlready) {
-                $this->implEnsureParentId(
+                yield [
                     $isTracerEnabled,
-                    $doesTxHaveParentAlready
-                );
+                    $doesTxHaveParentAlready,
+                ];
             }
         }
     }
 
-    public function implEnsureParentId(bool $isTracerEnabled, bool $doesTxHaveParentAlready): void
+    /**
+     * @dataProvider dataPrividerForTestEnsureParentId
+     *
+     * @param bool $isTracerEnabled
+     * @param bool $doesTxHaveParentAlready
+     */
+    public function testEnsureParentId(bool $isTracerEnabled, bool $doesTxHaveParentAlready): void
     {
         // Arrange
 
@@ -229,22 +538,29 @@ class DistributedTracingTest extends TracerUnitTestCaseBase
         /** @var ?TransactionInterface */
         $webFrontTx = null;
 
-        /** @var ?string */
-        $distTracingData = null;
+        /** @var array<string, string> */
+        $distTracingData = [];
 
         if ($doesTxHaveParentAlready) {
             GlobalTracerHolder::set($webFrontTracer);
             $webFrontTx = ElasticApm::beginCurrentTransaction('web front end TX', 'web front end TX type');
-            $distTracingData = ElasticApm::getSerializedCurrentDistributedTracingData();
+            ElasticApm::injectDistributedTracingHeaders(
+                function (string $headerName, string $headerValue) use (&$distTracingData): void {
+                    $distTracingData[$headerName] = $headerValue;
+                }
+            );
         }
 
         GlobalTracerHolder::set($backendServiceTracer);
-        $backendServiceTx = ElasticApm::beginCurrentTransaction(
-            'backend service TX',
-            'backend service TX type',
-            /* timestamp: */ null,
-            $distTracingData
-        );
+        $headerExtractor = function (string $headerName) use ($distTracingData): ?string {
+            return array_key_exists($headerName, $distTracingData)
+                ? $distTracingData[$headerName]
+                : null;
+        };
+        $backendServiceTx = ElasticApm::newTransaction('backend service TX', 'backend service TX type')
+                                      ->asCurrent()
+                                      ->distributedTracingHeaderExtractor($headerExtractor)
+                                      ->begin();
         $parentId = ElasticApm::getCurrentTransaction()->ensureParentId();
         $backendServiceTx->end();
 

--- a/tests/ElasticApmTests/Util/TestCaseBase.php
+++ b/tests/ElasticApmTests/Util/TestCaseBase.php
@@ -436,7 +436,6 @@ class TestCaseBase extends TestCase
         }
 
         TestCase::assertInstanceOf(TransactionData::class, $execSegData, DbgUtil::getType($execSegData));
-        /** @noinspection PhpPossiblePolymorphicInvocationInspection */
         return $execSegData->context;
     }
 
@@ -519,6 +518,17 @@ class TestCaseBase extends TestCase
         self::assertArrayNotHasKey($key, $context->labels);
     }
 
+    /**
+     * @param mixed[] $expected
+     * @param mixed[] $actual
+     */
+    public static function assertEqualLists(array $expected, array $actual): void
+    {
+        self::assertTrue(sort(/* ref */ $expected));
+        self::assertTrue(sort(/* ref */ $actual));
+        self::assertEqualsCanonicalizing($expected, $actual);
+    }
+
     public static function buildTracerForTests(?EventSinkInterface $eventSink = null): TracerBuilderForTests
     {
         return TracerBuilderForTests::startNew()
@@ -543,7 +553,6 @@ class TestCaseBase extends TestCase
         }
 
         TestCase::assertInstanceOf(TransactionData::class, $execSegData, DbgUtil::getType($execSegData));
-        /** @noinspection PhpPossiblePolymorphicInvocationInspection */
         return $execSegData->parentId;
     }
 
@@ -556,7 +565,6 @@ class TestCaseBase extends TestCase
         }
 
         TestCase::assertInstanceOf(TransactionData::class, $execSegData, DbgUtil::getType($execSegData));
-        /** @noinspection PhpPossiblePolymorphicInvocationInspection */
         $execSegData->parentId = $newParentId;
     }
 


### PR DESCRIPTION
Closes #435
Closes #447

- On the sending side Instead of `getSerializedCurrentDistributedTracingData()` (which is now deprecated) a new API was implemented - `injectDistributedTracingHeaders()` that accepts a callback where the callback contains the actual implementation of injecting headers to the outgoing request. This way user of the API doesn't need to know how many headers need to be injected and what are their names.
- On the receiving side instead of passing `$serializedDistTracingData` to `beginCurrentTransaction()` (which is now deprecated as well) a new API was implemented that accepts a callback where the callback contains the actual implementation of reading  headers to the incoming request. This way user of the API doesn't need to know how many headers were injecteded and what are their names.