### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/error.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/error.json
@@ -17,9 +17,6 @@
             "object"
           ]
         },
-        "experimental": {
-          "description": "Experimental information is only processed when APM Server is started in development mode and should only be used by APM agent developers implementing new, unreleased features. The format is unspecified."
-        },
         "message": {
           "description": "Message holds details related to message receiving and publishing if the captured event integrates with a messaging system",
           "type": [

--- a/tests/APM_Server_intake_API_schema/latest_used/span.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/span.json
@@ -166,9 +166,6 @@
             }
           }
         },
-        "experimental": {
-          "description": "Experimental information is only processed when APM Server is started in development mode and should only be used by APM agent developers implementing new, unreleased features. The format is unspecified."
-        },
         "http": {
           "description": "HTTP contains contextual information when the span concerns an HTTP request.",
           "type": [

--- a/tests/APM_Server_intake_API_schema/latest_used/transaction.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/transaction.json
@@ -16,9 +16,6 @@
             "object"
           ]
         },
-        "experimental": {
-          "description": "Experimental information is only processed when APM Server is started in development mode and should only be used by APM agent developers implementing new, unreleased features. The format is unspecified."
-        },
         "message": {
           "description": "Message holds details related to message receiving and publishing if the captured event integrates with a messaging system",
           "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/664120cf6 Remove `apm-server.mode` and experimental fields (https://github.com/elastic/apm-server/pull/6086)