### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/transaction.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/transaction.json
@@ -733,22 +733,6 @@
               "unknown",
               null
             ]
-          },
-          "subtype": {
-            "description": "Subtype is a further sub-division of the type (e.g. postgresql, elasticsearch)",
-            "type": [
-              "null",
-              "string"
-            ],
-            "maxLength": 1024
-          },
-          "type": {
-            "description": "Type holds the dropped span's type, and can have specific keywords within the service's domain (eg: 'request', 'backgroundjob', etc)",
-            "type": [
-              "null",
-              "string"
-            ],
-            "maxLength": 1024
           }
         }
       },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/e004300a9 dropped_spans_stats: Remove `type`, `subtype` fields (https://github.com/elastic/apm-server/pull/6268)