### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/metricset.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/metricset.json
@@ -129,6 +129,31 @@
         }
       }
     },
+    "service": {
+      "description": "Service holds selected information about the correlated service.",
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the correlated service.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        },
+        "version": {
+          "description": "Version of the correlated service.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        }
+      }
+    },
     "span": {
       "description": "Span holds selected information about the correlated transaction.",
       "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/ca46e12d5 Added support for overwriting the service.name for metricset objects (https://github.com/elastic/apm-server/pull/6388) (https://github.com/elastic/apm-server/pull/6407)