### PR TITLE
[1.x] docs: Link to APM guide

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -143,7 +143,7 @@ while `/user/*?lang=*` does not match `http://my_site.com/user/Alice?lang=en`
 |============
 
 This string is used to ensure that only your agents can send data to your APM Server.
-You must have created the API key using the APM Server {apm-server-ref-v}/api-key.html[command line tool].
+You must have created the API key using the APM Server {apm-guide-ref}/api-key.html[command line tool].
 
 <<config-api-key>> is an alternative to <<config-secret-token>>.
 If both <<config-secret-token>> and <<config-api-key>> are configured,
@@ -364,7 +364,7 @@ See <<configure-logging>> for details.
 This string is used to ensure that only your agents can send data to your APM Server.
 Both the agents and the APM Server have to be configured with the same secret token.
 
-See {apm-server-ref-v}/secret-token.html[the relevant APM Server's documentation]
+See {apm-guide-ref}/secret-token.html[the relevant APM Server's documentation]
 on how to configure APM Server's secret token.
 
 Use this setting if the APM Server requires a token, like in {ess}.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -16,6 +16,6 @@ It is an extension that must be installed in your PHP environment.
 [float]
 [[additional-components]]
 === Additional Components
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -105,7 +105,7 @@ A transaction describes an event captured by an Elastic APM agent monitoring a s
 Transactions help combine multiple <<api-span-interface,Spans>> into logical groups,
 and they are the first <<api-span-interface,Span>> of a service.
 More information on Transactions and Spans is available
-in the {apm-overview-ref-v}/apm-data-model.html[APM data model] documentation.
+in the {apm-guide-ref}/data-model.html[APM data model] documentation.
 
 See <<api-elasticapm-class-get-current-transaction>> on how to get a reference to the current transaction.
 


### PR DESCRIPTION
Backports https://github.com/elastic/apm-agent-php/pull/608 to 1.x.