### PR TITLE
release: create PR targetting 'main'

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -561,7 +561,7 @@ def prepareRelease() {
     sh(label: 'Git commit', script: """git commit -a -m "${message}" """)
     def pr = githubCreatePullRequest(title: "[RELEASE] ${params.VERSION}",
                                      description: "${warning}\n\n${actions}",
-                                     labels: 'docs,release,changelog'
+                                     labels: 'docs,release,changelog',
                                      base: 'main')
     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Prepare ${params.VERSION} release steps to be validated.",
                  body: """Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours ONLY If no changes are required. Otherwise stop it and review the (<${pr}|PR>).""")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -561,7 +561,8 @@ def prepareRelease() {
     sh(label: 'Git commit', script: """git commit -a -m "${message}" """)
     def pr = githubCreatePullRequest(title: "[RELEASE] ${params.VERSION}",
                                      description: "${warning}\n\n${actions}",
-                                     labels: 'docs,release,changelog')
+                                     labels: 'docs,release,changelog'
+                                     base: 'main')
     notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Prepare ${params.VERSION} release steps to be validated.",
                  body: """Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours ONLY If no changes are required. Otherwise stop it and review the (<${pr}|PR>).""")
     if (askAndWait("You are about to release version ${params.VERSION}. If you approve then changes will be committed and pushed. Review ${pr}.")) {


### PR DESCRIPTION
### What

Trying to fix an issue with the PR creation:

```
[2022-02-14T13:03:12.856Z] Error creating pull request: Unprocessable Entity (HTTP 422)
[2022-02-14T13:03:12.856Z] Invalid value for "base"
```

`base` is empty in any case, but maybe it's somehow pointing to `master` in the `hub` internals?

Let's enforce `--base` to `main`

