### PR TITLE
ci: speed up release tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
             }
           }
         }
-        stage('Prepara Release') {
+        stage('Prepare Release') {
           options {
             skipDefaultCheckout()
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,10 +100,6 @@ pipeline {
             }
             stages {
               stage('Build') {
-                when {
-                  beforeAgent true
-                  not { expression { isInternalCI() } }
-                }
                 steps {
                   initWorkspace(context: "Build-${PHP_VERSION}") {
                     // When running in the CI with multiple parallel stages

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,6 +100,10 @@ pipeline {
             }
             stages {
               stage('Build') {
+                when {
+                  beforeAgent true
+                  not { expression { isInternalCI() } }
+                }
                 steps {
                   initWorkspace(context: "Build-${PHP_VERSION}") {
                     // When running in the CI with multiple parallel stages
@@ -112,6 +116,10 @@ pipeline {
                 }
               }
               stage('Static check and Unit Tests') {
+                when {
+                  beforeAgent true
+                  not { expression { isInternalCI() } }
+                }
                 steps {
                   withGithubNotify(context: "Static-Check-Unit-Tests-${PHP_VERSION}", tab: 'tests') {
                     dir("${BASE_DIR}"){
@@ -177,7 +185,10 @@ pipeline {
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
-            expression { return env.ONLY_DOCS == "false" }
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+              not { expression { isInternalCI() } }
+            }
           }
           steps {
             generateSteps()


### PR DESCRIPTION
### What

Skip UTs and lifecycle-testing  pre-release stages in favour of a lighter release pipeline.

### Why

Tag releases are based on commits which have been verified on a PR basis and also in each branch.

Therefore, a tag release does not need to validate the UTs again, but only run the steps in the `internal-ci`.

Given the release `1.4.2`

<img width="2374" alt="image" src="https://user-images.githubusercontent.com/2871786/159932151-d84450d1-2e02-4860-a55e-10dfdd26130a.png">


Then these changes will skip:

1. `Static check and Unit Tests` stages in the `BuildAndTest` matrix
1. `Package lifecycle testing` matrix stage.