### PR TITLE
ci: change message for tag releases

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           steps {
             whenTrue(isInternalCI() && isTag()) {
               setEnvVar('PRE_RELEASE_STAGE', 'true')
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Buiild for the release tag *${env.TAG_NAME}* has been triggered", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
             }
             whenTrue(params.VERSION?.trim() ? true : false) {
               script {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           steps {
             whenTrue(isInternalCI() && isTag()) {
               setEnvVar('PRE_RELEASE_STAGE', 'true')
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Buiild for the release tag *${env.TAG_NAME}* has been triggered", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Build for the release tag *${env.TAG_NAME}* has been triggered", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
             }
             whenTrue(params.VERSION?.trim() ? true : false) {
               script {


### PR DESCRIPTION
### What

Tag releases are event based, so a build could happen because the tag has been created or the the build has been manually triggered.

Let's support both cases by using a more generic message in the notifications