### PR TITLE
release: add sleep

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -14,6 +14,8 @@ github-release release \
     --tag "${TAG_NAME}" \
     --description "For more information, please see the [changelog](https://www.elastic.co/guide/en/apm/agent/php/current/release-notes.html)."
 
+echo "INFO: sleep since the release might not be available in GitHub yet"
+sleep 5
 echo "INFO: Gather release details"
 github-release info \
     --user ${USER} \


### PR DESCRIPTION
It's trying to fix some issues while uploading the artifacts for the just created release:

```
[2022-03-30T10:40:29.285Z] + echo 'INFO: Create GitHub release'
[2022-03-30T10:40:29.285Z] INFO: Create GitHub release
[2022-03-30T10:40:29.286Z] + github-release release --user elastic --repo apm-agent-php --tag v1.5 --description 'For more information, please see the [changelog](https://www.elastic.co/guide/en/apm/agent/php/current/release-notes.html).'
[2022-03-30T10:40:30.391Z] + echo 'INFO: Gather release details'
[2022-03-30T10:40:30.391Z] INFO: Gather release details
[2022-03-30T10:40:30.391Z] + github-release info --user elastic --repo apm-agent-php --tag v1.5
[2022-03-30T10:40:30.894Z] error: could not find the release corresponding to tag v1.5
```