### PR TITLE
ci: stage approval after the tests and more parallel stages for the test signed meta-stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -217,15 +217,6 @@ pipeline {
         RELEASE_URL_MESSAGE = "(<https://github.com/elastic/apm-agent-php/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
       }
       stages {
-        stage('Approve to Publish') {
-          options { skipDefaultCheckout() }
-          steps {
-            setEnvVar('PRE_RELEASE_STAGE', 'false')
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}@${env.TAG_NAME}] Release ready to be published",
-                         body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.\n Changes: ${env.TAG_NAME}")
-            setEnvVar('RELEASE', askAndWait("You are about to release version ${env.TAG_NAME}. Do you wish to release it?"))
-          }
-        }
         stage('Signing CI') {
           when {
             beforeAgent true
@@ -284,6 +275,15 @@ pipeline {
                 }
               }
             }
+          }
+        }
+        stage('Approve to Publish') {
+          options { skipDefaultCheckout() }
+          steps {
+            setEnvVar('PRE_RELEASE_STAGE', 'false')
+            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}@${env.TAG_NAME}] Release ready to be published",
+                         body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.\n Changes: ${env.TAG_NAME}")
+            setEnvVar('RELEASE', askAndWait("You are about to release version ${env.TAG_NAME}. Do you wish to release it?"))
           }
         }
         stage('Publish') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
             }
           }
           steps {
-            generateSteps()
+            generateSteps("generate_stages_list.sh")
           }
         }
       }
@@ -248,32 +248,12 @@ pipeline {
         }
         stage('Test-Signed-Package') {
           options { skipDefaultCheckout() }
-          failFast false
-          matrix {
-            agent { label 'ubuntu-18.04 && immutable' }
-            axes {
-              axis {
-                name 'PHP_VERSION'
-                values '7.2', '7.3', '7.4', '8.0', '8.1'
-              }
-            }
-            stages {
-              stage('Release Test') {
-                steps {
-                  initWorkspace(context: "Signed-Test-${PHP_VERSION}") {
-                      unstash "${env.SIGNED_ARTIFACTS}"
-                      sh script: "PHP_VERSION=${PHP_VERSION} make -C packaging install", label: 'package install'
-                  }
-                }
-                post {
-                  unsuccessful {
-                    notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* got some test failures in the installers.", body: "Please review the signed binaries are healthy (<${env.RUN_DISPLAY_URL}|Open>)")
-                  }
-                  always {
-                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
-                  }
-                }
-              }
+          steps {
+            generateSteps("generate_stages_list_smoke.sh")
+          }
+          post {
+            unsuccessful {
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* got some test failures in the installers.", body: "Please review the signed binaries are healthy (<${env.RUN_DISPLAY_URL}|Open>)")
             }
           }
         }
@@ -502,10 +482,10 @@ def prepareRelease() {
   }
 }
 
-def generateSteps() {
+def generateSteps(file) {
   def parallelTasks = [:]
   dir("${BASE_DIR}"){
-    def output = sh(label: '.ci/generate_stages_list.sh', script: '.ci/generate_stages_list.sh', returnStdout: true)
+    def output = sh(label: ".ci/${file}", script: ".ci/${file}", returnStdout: true)
     if (output?.trim()) {
       output.split('\n').each { content ->
         parallelTasks[content] = generateStep(content)
@@ -543,6 +523,9 @@ def generateStep(String content){
         withEnv(["COMPONENT_TEST_SCRIPT=${parsedContent[3]}"]) {
           lifecycleTesting(php, dist, env.COMPONENT_TEST_SCRIPT)
         }
+      }
+      if (target.equals('signed-testing')) {
+        signedTesting(php, dist)
       }
     }
   }
@@ -591,5 +574,18 @@ def phpFpmTesting(php, dist) {
     packageWorkspace(context: "PHP-FPM-Testing-${php}-${dist}", prepareGoal: "prepare-${dist}-fpm") {
       sh(script: "make -C packaging ${dist}-lifecycle-testing-in-fpm", label: "${dist}-lifecycle-testing-in-fpm")
     }
+  }
+}
+
+def signedTesting(php, dist) {
+  try {
+    withEnv(["PHP_VERSION=${php}"]) {
+      initWorkspace(context: "Signed-Testing-${php}-${dist}") {
+        unstash "${env.SIGNED_ARTIFACTS}"
+        sh(script: "PHP_VERSION=${php} make -C packaging install-${dist}", label: "package install-${dist}")
+      }
+    }
+  } finally {
+    junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/phpunit-*junit.xml")
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -582,7 +582,7 @@ def signedTesting(php, dist) {
     withEnv(["PHP_VERSION=${php}"]) {
       initWorkspace(context: "Signed-Testing-${php}-${dist}") {
         unstash "${env.SIGNED_ARTIFACTS}"
-        sh(script: "PHP_VERSION=${php} make -C packaging install-${dist}", label: "package install-${dist}")
+        sh(script: "PHP_VERSION=${php} make -C packaging ${dist}-install", label: "package ${dist}-install")
       }
     }
   } finally {

--- a/.ci/generate_stages_list_smoke.sh
+++ b/.ci/generate_stages_list_smoke.sh
@@ -2,7 +2,7 @@
 set -e
 
 #
-# lifecycle-testing
+# install-testing
 #
 for phpVersion in 7.2 7.3 7.4 8.0 8.1
 do

--- a/.ci/generate_stages_list_smoke.sh
+++ b/.ci/generate_stages_list_smoke.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# lifecycle-testing
+#
+for phpVersion in 7.2 7.3 7.4 8.0 8.1
+do
+    for linuxDistro in apk deb rpm tar
+    do
+        echo ${phpVersion},${linuxDistro},install-testing
+    done
+done
+


### PR DESCRIPTION
### What

- `generateSteps` is now dynamic, so it executes the given `file.sh` script
- Convert the `Test-Signed-Package` matrix, executed during a release, in a dynamic scripted parallel.
- Support distro granularity, therefore, `Test-Signed-Package` meta-stage will take less time
- Move approval after the test signed package stage.

### Why

Faster releases, allow fine granularity, so @SergeyKleyman can now change `.ci/generate_stages_list_smoke.sh` to run the required tests

Avoid spamming if the signed packages failed.