### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/error.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/error.json
@@ -601,6 +601,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/tests/APM_Server_intake_API_schema/latest_used/span.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/span.json
@@ -516,6 +516,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/tests/APM_Server_intake_API_schema/latest_used/transaction.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/transaction.json
@@ -600,6 +600,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/d1b5503a6 Extend intake API to accept info about target service (https://github.com/elastic/apm-server/pull/7870)