### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/span.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/span.json
@@ -147,7 +147,7 @@
                   "maxLength": 1024
                 },
                 "resource": {
-                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name'",
+                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name' DEPRECATED: this field will be removed in a future release",
                   "type": "string",
                   "maxLength": 1024
                 },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/6dbbc4c23 Make service target backward compatible with destination resource (https://github.com/elastic/apm-server/pull/7925)