### PR TITLE
ci: force a new workspace and unique worker

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -485,7 +485,7 @@ def generatePackageLifecycleTestMatrix(def args = [:]) {
 
 def generatePackageLifecycleTestMatrixRow(def args = [:]){
   return {
-    withNode(labels: 'ubuntu-18.04 && immutable') {
+    withNode(labels: 'ubuntu-18.04 && immutable', sleepMax: 60, forceWorspace: true, forceWorker: true) {
       def testingArgs =  [:]
       testingArgs['shouldUseSignedBinaries'] = args.shouldUseSignedBinaries
       def parsedTestMatrixRow = args.testMatrixRow.split(',')


### PR DESCRIPTION
### What

Force a new workspace and CI workers with some latency:

### Why

There are some errors when deleting the workspace in a new CI worker...


https://github.com/elastic/apm-pipeline-library/blob/main/vars/withNode.groovy#L19-L22 could help though the CI platform provided a feature to avoid the issue with reusing workers...

>  1. with some latency to avoid the known issue with the scalability in gobld.
>  2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
>  3. allocate a new workspace to workaround the flakiness of windows workers with deleteDir.

`gobld` is the elastic specific CI provisioner which runs outside of the Jenkins itself (no plugin based)

### Issue

```
[2022-09-23T06:31:30.550Z] 	Also:   java.nio.file.FileSystemException: /var/lib/jenkins/workspace/ent-php_apm-agent-php-mbp_PR-777/src/go.elastic.co/apm/apm-agent-php/vendor/squizlabs/php_codesniffer/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php: Operation not permitted
[2022-09-23T06:31:30.550Z] 			at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
[2022-09-23T06:31:30.550Z] 			at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
[2022-09-23T06:31:30.550Z] 			at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
[2022-09-23T06:31:30.550Z] 			at sun.nio.fs.UnixFileAttributeViews$Posix.setMode(UnixFileAttributeViews.java:238)
[2022-09-23T06:31:30.550Z] 			at sun.nio.fs.UnixFileAttributeViews$Posix.setPermissions(UnixFileAttributeViews.java:260)
[2022-09-23T06:31:30.550Z] 			at java.nio.file.Files.setPosixFilePermissions(Files.java:2045)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.makeWritable(PathRemover.java:285)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.makeRemovable(PathRemover.java:258)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:238)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
[2022-09-23T06:31:30.550Z] 			at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
[2022-09-23T06:31:30.550Z] 	Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to apm-ci-immutable-ubuntu-1804-1663913049530070440
[2022-09-23T06:31:30.550Z] 			at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1784)
[2022-09-23T06:31:30.550Z] 			at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:356)
[2022-09-23T06:31:30.550Z] 			at hudson.remoting.Channel.call(Channel.java:1000)
[2022-09-23T06:31:30.550Z] 			at hudson.FilePath.act(FilePath.java:1194)
[2022-09-23T06:31:30.550Z] 			at hudson.FilePath.act(FilePath.java:1183)
[2022-09-23T06:31:30.550Z] 			at hudson.FilePath.deleteRecursive(FilePath.java:1436)
[2022-09-23T06:31:30.550Z] 			at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:79)
[2022-09-23T06:31:30.550Z] 			at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:71)
[2022-09-23T06:31:30.550Z] 			at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[2022-09-23T06:31:30.550Z] 			at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2022-09-23T06:31:30.550Z] 			at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2022-09-23T06:31:30.550Z] 			at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2022-09-23T06:31:30.550Z] 			at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2022-09-23T06:31:30.550Z] jenkins.util.io.CompositeIOException: Unable to delete '/var/lib/jenkins/workspace/ent-php_apm-agent-php-mbp_PR-777'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts. (Discarded 3493 additional exceptions)
[2022-09-23T06:31:30.550Z] jenkins.util.io.CompositeIOException: Unable to delete '/var/lib/jenkins/workspace/ent-php_apm-agent-php-mbp_PR-777'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts. (Discarded 3493 additional exceptions)
[2022-09-23T06:31:30.550Z] 	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:96)
[2022-09-23T06:31:30.550Z] 	at hudson.Util.deleteRecursive(Util.java:320)
[2022-09-23T06:31:30.550Z] 	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1444)
[2022-09-23T06:31:30.550Z] 	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1439)
[2022-09-23T06:31:30.550Z] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3502)
[2022-09-23T06:31:30.550Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
[2022-09-23T06:31:30.550Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
[2022-09-23T06:31:30.550Z] 	at hudson.remoting.Request$2.run(Request.java:376)
[2022-09-23T06:31:30.550Z] 	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
[2022-09-23T06:31:30.550Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2022-09-23T06:31:30.550Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2022-09-23T06:31:30.550Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2022-09-23T06:31:30.550Z] 	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:122)
[2022-09-23T06:31:30.550Z] 	at java.lang.Thread.run(Thread.java:750)
[2022-09-23T06:31:31.825Z] 
```

### Caveats

The top-level CI worker uses a different syntax, so it's not supported by this particular proposal