### PR TITLE
Follow LSB for additional packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build/
 
 # Temporary files
 /_TEMP/
+
+# Generated build dependency sets
+*.dep

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN docker-php-ext-install \
     pdo_mysql \
     pdo_sqlite
 
-COPY --from=composer:2.3.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.3.5 /usr/bin/composer /usr/local/bin/composer
 
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-Linux-x86_64.tar.gz -O /tmp/cmake.tar.gz \
-      && mkdir /usr/bin/cmake \
-      && tar -xpf /tmp/cmake.tar.gz --strip-components=1 -C /usr/bin/cmake \
+      && mkdir /opt/cmake/ \
+      && tar -xpf /tmp/cmake.tar.gz --strip-components=1 -C /opt/cmake/ \
       && rm /tmp/cmake.tar.gz
 
-ENV PATH="/usr/bin/cmake/bin:${PATH}"
+ENV PATH="/opt/cmake/bin:${PATH}"
 
 WORKDIR /app/src/ext
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,7 +21,7 @@ RUN docker-php-ext-install \
     pdo_mysql \
     pdo_sqlite
 
-COPY --from=composer:2.3.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.3.5 /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /app/src/ext
 


### PR DESCRIPTION
Small cosmetic changes to follow LSB in dev env Dockerfiles

In `Dockerfile`:
 * Install cmake to `/opt/cmake` instead of `/usr/bin/cmake`
 * Install composer to `/usr/local/bin`

In `Dockerfile.alpine`:
 * Install composer to `/usr/local/bin`