### PR TITLE
Use Assert base class instead of TestCase when referencing assertions

### DIFF
--- a/tests/ElasticApmTests/ComponentTests/ConfigSettingTest.php
+++ b/tests/ElasticApmTests/ComponentTests/ConfigSettingTest.php
@@ -36,7 +36,7 @@ use ElasticApmTests\ComponentTests\Util\AppCodeTarget;
 use ElasticApmTests\ComponentTests\Util\ComponentTestCaseBase;
 use ElasticApmTests\ComponentTests\Util\HttpAppCodeRequestParams;
 use ElasticApmTests\Util\TransactionExpectations;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 
 /**
@@ -219,7 +219,7 @@ final class ConfigSettingTest extends ComponentTestCaseBase
     public static function appCodeForTestAllWaysToSetConfig(array $appCodeArgs): void
     {
         $optName = self::getMandatoryAppCodeArg($appCodeArgs, self::APP_CODE_ARGS_KEY_OPTION_NAME);
-        TestCase::assertIsString($optName);
+        Assert::assertIsString($optName);
         /** @var string $optName */
         $optExpectedVal = self::getMandatoryAppCodeArg($appCodeArgs, self::APP_CODE_ARGS_KEY_OPTION_EXPECTED_VALUE);
 

--- a/tests/ElasticApmTests/ComponentTests/CurlAutoInstrumentationTest.php
+++ b/tests/ElasticApmTests/ComponentTests/CurlAutoInstrumentationTest.php
@@ -33,7 +33,7 @@ use ElasticApmTests\ComponentTests\Util\ExpectedEventCounts;
 use ElasticApmTests\ComponentTests\Util\HttpClientUtilForTests;
 use ElasticApmTests\ComponentTests\Util\HttpServerHandle;
 use ElasticApmTests\ComponentTests\Util\TestInfraDataPerRequest;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @group does_not_require_external_services
@@ -47,7 +47,7 @@ final class CurlAutoInstrumentationTest extends ComponentTestCaseBase
 
     private static function assertCurlExtensionIsLoaded(): void
     {
-        TestCase::assertTrue(extension_loaded('curl'));
+        Assert::assertTrue(extension_loaded('curl'));
     }
 
     /**

--- a/tests/ElasticApmTests/ComponentTests/MetadataTest.php
+++ b/tests/ElasticApmTests/ComponentTests/MetadataTest.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\MetadataDiscoverer;
 use Elastic\Apm\Impl\Tracer;
 use ElasticApmTests\ComponentTests\Util\ComponentTestCaseBase;
 use ElasticApmTests\Util\MetadataValidator;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @group smoke
@@ -62,7 +62,7 @@ final class MetadataTest extends ComponentTestCaseBase
     {
         $dataFromAgent = $this->configTestImpl(OptionNames::ENVIRONMENT, $configured);
         foreach ($dataFromAgent->metadatas as $metadata) {
-            TestCase::assertSame($expected, $metadata->service->environment);
+            Assert::assertSame($expected, $metadata->service->environment);
         }
     }
 
@@ -91,7 +91,7 @@ final class MetadataTest extends ComponentTestCaseBase
     {
         $dataFromAgent = $this->configTestImpl(OptionNames::SERVICE_NAME, $configured);
         foreach ($dataFromAgent->metadatas as $metadata) {
-            TestCase::assertSame($expected, $metadata->service->name);
+            Assert::assertSame($expected, $metadata->service->name);
         }
     }
 
@@ -137,7 +137,7 @@ final class MetadataTest extends ComponentTestCaseBase
     {
         $dataFromAgent = $this->configTestImpl(OptionNames::SERVICE_VERSION, $configured);
         foreach ($dataFromAgent->metadatas as $metadata) {
-            TestCase::assertSame($expected, $metadata->service->version);
+            Assert::assertSame($expected, $metadata->service->version);
         }
     }
 
@@ -194,7 +194,7 @@ final class MetadataTest extends ComponentTestCaseBase
     {
         $dataFromAgent = $this->configTestImpl(OptionNames::SERVICE_NODE_NAME, $configured);
         foreach ($dataFromAgent->metadatas as $metadata) {
-            TestCase::assertSame($expected, $metadata->service->nodeConfiguredName);
+            Assert::assertSame($expected, $metadata->service->nodeConfiguredName);
         }
     }
 

--- a/tests/ElasticApmTests/ComponentTests/MySQLi/ApiFacade.php
+++ b/tests/ElasticApmTests/ComponentTests/MySQLi/ApiFacade.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Log\Logger;
 use ElasticApmTests\ComponentTests\Util\AmbientContextForTests;
 use ElasticApmTests\Util\LogCategoryForTests;
 use mysqli;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -77,7 +77,7 @@ final class ApiFacade implements LoggableInterface
         );
 
         if (!self::canDbNameBeNull()) {
-            TestCase::assertNotNull($dbName);
+            Assert::assertNotNull($dbName);
         }
 
         $wrappedObj = $this->isOOPApi

--- a/tests/ElasticApmTests/ComponentTests/MySQLi/MySQLiWrapped.php
+++ b/tests/ElasticApmTests/ComponentTests/MySQLi/MySQLiWrapped.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\ComponentTests\MySQLi;
 use Elastic\Apm\Impl\Log\LoggableInterface;
 use Elastic\Apm\Impl\Log\LoggableTrait;
 use mysqli;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -138,7 +138,7 @@ final class MySQLiWrapped implements LoggableInterface
     public function error(): string
     {
         $result = $this->isOOPApi ? $this->wrappedObj->error : mysqli_error($this->wrappedObj);
-        TestCase::assertNotNull($result);
+        Assert::assertNotNull($result);
         return $result;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/MySQLiTest.php
+++ b/tests/ElasticApmTests/ComponentTests/MySQLiTest.php
@@ -44,7 +44,7 @@ use ElasticApmTests\ComponentTests\Util\ExpectedEventCounts;
 use ElasticApmTests\Util\DataProviderForTestBuilder;
 use ElasticApmTests\Util\SpanExpectations;
 use ElasticApmTests\Util\SpanSequenceValidator;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @group smoke
@@ -152,32 +152,32 @@ final class MySQLiTest extends ComponentTestCaseBase
                     }
                     $multiQuery .= $query;
                 }
-                TestCase::assertTrue($mySQLi->multiQuery($multiQuery));
+                Assert::assertTrue($mySQLi->multiQuery($multiQuery));
                 while (true) {
                     $result = $mySQLi->storeResult();
                     if ($result === false) {
-                        TestCase::assertEmpty($mySQLi->error());
+                        Assert::assertEmpty($mySQLi->error());
                     } else {
                         $result->close();
                     }
                     if (!$mySQLi->moreResults()) {
                         break;
                     }
-                    TestCase::assertTrue($mySQLi->nextResult());
+                    Assert::assertTrue($mySQLi->nextResult());
                 }
                 break;
             case self::QUERY_KIND_REAL_QUERY:
                 foreach ($queries as $query) {
-                    TestCase::assertTrue($mySQLi->realQuery($query));
+                    Assert::assertTrue($mySQLi->realQuery($query));
                 }
                 break;
             case self::QUERY_KIND_QUERY:
                 foreach ($queries as $query) {
-                    TestCase::assertTrue($mySQLi->query($query));
+                    Assert::assertTrue($mySQLi->query($query));
                 }
                 break;
             default:
-                TestCase::fail();
+                Assert::fail();
         }
     }
 
@@ -211,7 +211,7 @@ final class MySQLiTest extends ComponentTestCaseBase
                 }
                 break;
             default:
-                TestCase::fail();
+                Assert::fail();
         }
     }
 
@@ -221,7 +221,7 @@ final class MySQLiTest extends ComponentTestCaseBase
     private static function allDbNames(): array
     {
         $defaultDbName = AmbientContextForTests::testConfig()->mysqlDb;
-        TestCase::assertNotNull($defaultDbName);
+        Assert::assertNotNull($defaultDbName);
         return [$defaultDbName, $defaultDbName . '_ALT'];
     }
 
@@ -415,7 +415,7 @@ final class MySQLiTest extends ComponentTestCaseBase
      */
     public function testAutoInstrumentation(array $testArgs): void
     {
-        TestCase::assertNotCount(0, self::MESSAGES);
+        Assert::assertNotCount(0, self::MESSAGES);
 
         $logger = self::getLoggerStatic(__NAMESPACE__, __CLASS__, __FILE__);
         ($loggerProxy = $logger->ifTraceLevelEnabled(__LINE__, __FUNCTION__))

--- a/tests/ElasticApmTests/ComponentTests/TransactionMaxSpansComponentTest.php
+++ b/tests/ElasticApmTests/ComponentTests/TransactionMaxSpansComponentTest.php
@@ -37,7 +37,7 @@ use ElasticApmTests\ComponentTests\Util\ExpectedEventCounts;
 use ElasticApmTests\TestsSharedCode\TransactionMaxSpansTest\Args;
 use ElasticApmTests\TestsSharedCode\TransactionMaxSpansTest\SharedCode;
 use ElasticApmTests\Util\TransactionExpectations;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @group smoke
@@ -65,8 +65,8 @@ final class TransactionMaxSpansComponentTest extends ComponentTestCaseBase
     public static function appCodeForTestVariousCombinations(array $args): void
     {
         $testArgsAsDecodedJson = ArrayUtil::getValueIfKeyExistsElse('testArgs', $args, null);
-        TestCase::assertNotNull($testArgsAsDecodedJson);
-        TestCase::assertIsArray($testArgsAsDecodedJson);
+        Assert::assertNotNull($testArgsAsDecodedJson);
+        Assert::assertIsArray($testArgsAsDecodedJson);
         $testArgs = new Args();
         $testArgs->deserializeFromDecodedJson($testArgsAsDecodedJson);
         SharedCode::appCode($testArgs, ElasticApm::getCurrentTransaction());

--- a/tests/ElasticApmTests/ComponentTests/Util/AmbientContextForTests.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AmbientContextForTests.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Log\Backend as LogBackend;
 use Elastic\Apm\Impl\Log\Level as LogLevel;
 use Elastic\Apm\Impl\Log\LoggerFactory;
 use ElasticApmTests\Util\LogSinkForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 
 final class AmbientContextForTests
@@ -64,7 +64,7 @@ final class AmbientContextForTests
     public static function init(string $dbgProcessName): void
     {
         if (self::$singletonInstance !== null) {
-            TestCase::assertSame(self::$singletonInstance->dbgProcessName, $dbgProcessName);
+            Assert::assertSame(self::$singletonInstance->dbgProcessName, $dbgProcessName);
             return;
         }
 
@@ -83,7 +83,7 @@ final class AmbientContextForTests
 
     private static function getSingletonInstance(): self
     {
-        TestCase::assertNotNull(self::$singletonInstance);
+        Assert::assertNotNull(self::$singletonInstance);
         return self::$singletonInstance;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostBase.php
@@ -31,7 +31,7 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\Util\ElasticApmExtensionUtil;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 use Throwable;
 
@@ -66,7 +66,7 @@ abstract class AppCodeHostBase extends SpawnedProcessBase
     {
         self::runSkeleton(
             function (SpawnedProcessBase $thisObj) use (&$topLevelCodeId): void {
-                TestCase::assertInstanceOf(self::class, $thisObj);
+                Assert::assertInstanceOf(self::class, $thisObj);
 
                 if (!ElasticApmExtensionUtil::isLoaded()) {
                     throw new RuntimeException(
@@ -98,12 +98,12 @@ abstract class AppCodeHostBase extends SpawnedProcessBase
     protected function callAppCode(?string &$topLevelCodeId): void
     {
         $dataPerRequest = AmbientContextForTests::testConfig()->dataPerRequest;
-        TestCase::assertNotNull($dataPerRequest);
+        Assert::assertNotNull($dataPerRequest);
         $logCtx = ['dataPerRequest' => $dataPerRequest];
 
         self::setAgentEphemeralIdToSpawnedProcessInternalId();
 
-        TestCase::assertNotNull($dataPerRequest->appCodeTarget);
+        Assert::assertNotNull($dataPerRequest->appCodeTarget);
         $topLevelCodeId = $dataPerRequest->appCodeTarget->appCodeTopLevelId;
         if ($topLevelCodeId !== null) {
             return;
@@ -114,9 +114,9 @@ abstract class AppCodeHostBase extends SpawnedProcessBase
 
         $msg = LoggableToString::convert(AmbientContextForTests::testConfig());
         $appCodeTarget = $dataPerRequest->appCodeTarget;
-        TestCase::assertNotNull($appCodeTarget, $msg);
-        TestCase::assertNotNull($appCodeTarget->appCodeClass, $msg);
-        TestCase::assertNotNull($appCodeTarget->appCodeMethod, $msg);
+        Assert::assertNotNull($appCodeTarget, $msg);
+        Assert::assertNotNull($appCodeTarget->appCodeClass, $msg);
+        Assert::assertNotNull($appCodeTarget->appCodeMethod, $msg);
 
         try {
             $methodToCall = [$appCodeTarget->appCodeClass, $appCodeTarget->appCodeMethod];
@@ -148,7 +148,7 @@ abstract class AppCodeHostBase extends SpawnedProcessBase
         );
 
         $agentEphemeralId = AmbientContextForTests::testConfig()->dataPerProcess->thisSpawnedProcessInternalId;
-        TestCase::assertNotEmpty($agentEphemeralId);
+        Assert::assertNotEmpty($agentEphemeralId);
 
         ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Setting agentEphemeralId...', ['agentEphemeralId' => $agentEphemeralId]);

--- a/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostParams.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AppCodeHostParams.php
@@ -36,7 +36,7 @@ use Elastic\Apm\Impl\Util\ArrayUtil;
 use ElasticApmTests\UnitTests\Util\MockConfigRawSnapshotSource;
 use ElasticApmTests\Util\LogCategoryForTests;
 use ElasticApmTests\Util\RandomUtilForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class AppCodeHostParams implements LoggableInterface
 {
@@ -104,7 +104,7 @@ class AppCodeHostParams implements LoggableInterface
     {
         $result = [];
         foreach ($this->agentOptions as $optNameToVal) {
-            TestCase::assertIsArray($optNameToVal);
+            Assert::assertIsArray($optNameToVal);
             $result = array_merge($result, array_keys($optNameToVal));
         }
         return $result;

--- a/tests/ElasticApmTests/ComponentTests/Util/AppCodeTarget.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/AppCodeTarget.php
@@ -27,7 +27,7 @@ use Elastic\Apm\Impl\Log\LoggableInterface;
 use Elastic\Apm\Impl\Log\LoggableTrait;
 use ElasticApmTests\Util\Deserialization\JsonDeserializableInterface;
 use ElasticApmTests\Util\Deserialization\JsonDeserializableTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class AppCodeTarget implements JsonDeserializableInterface, LoggableInterface
 {
@@ -45,10 +45,10 @@ final class AppCodeTarget implements JsonDeserializableInterface, LoggableInterf
 
     public static function asRouted(callable $appCodeClassMethod): AppCodeTarget
     {
-        TestCase::assertIsCallable($appCodeClassMethod);
-        TestCase::assertIsArray($appCodeClassMethod);
+        Assert::assertIsCallable($appCodeClassMethod);
+        Assert::assertIsArray($appCodeClassMethod);
         /** @noinspection PhpParamsInspection */
-        TestCase::assertCount(2, $appCodeClassMethod);
+        Assert::assertCount(2, $appCodeClassMethod);
 
         $thisObj = new AppCodeTarget();
         $thisObj->appCodeClass = $appCodeClassMethod[0];

--- a/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerAppCodeHost.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/BuiltinHttpServerAppCodeHost.php
@@ -27,7 +27,7 @@ use Elastic\Apm\ElasticApm;
 use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Log\Logger;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 
 final class BuiltinHttpServerAppCodeHost extends AppCodeHostBase
@@ -73,7 +73,7 @@ final class BuiltinHttpServerAppCodeHost extends AppCodeHostBase
 
     protected function processConfig(): void
     {
-        TestCase::assertNotNull(
+        Assert::assertNotNull(
             AmbientContextForTests::testConfig()->dataPerProcess->thisServerPort,
             LoggableToString::convert(AmbientContextForTests::testConfig())
         );
@@ -93,7 +93,7 @@ final class BuiltinHttpServerAppCodeHost extends AppCodeHostBase
     protected function runImpl(?string &$topLevelCodeId): void
     {
         $dataPerRequest = AmbientContextForTests::testConfig()->dataPerRequest;
-        TestCase::assertNotNull($dataPerRequest);
+        Assert::assertNotNull($dataPerRequest);
         if (($response = self::verifySpawnedProcessInternalId($dataPerRequest->spawnedProcessInternalId)) !== null) {
             self::sendResponse($response);
             return;

--- a/tests/ElasticApmTests/ComponentTests/Util/ComponentTestCaseBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ComponentTestCaseBase.php
@@ -32,7 +32,7 @@ use Elastic\Apm\Impl\Util\ExceptionUtil;
 use ElasticApmTests\Util\DataFromAgent;
 use ElasticApmTests\Util\TestCaseBase;
 use ElasticApmTests\Util\TransactionDto;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 
 class ComponentTestCaseBase extends TestCaseBase
@@ -61,7 +61,7 @@ class ComponentTestCaseBase extends TestCaseBase
     public static function getTracerFromAppCode(): Tracer
     {
         $tracer = GlobalTracerHolder::getValue();
-        TestCase::assertInstanceOf(Tracer::class, $tracer);
+        Assert::assertInstanceOf(Tracer::class, $tracer);
         /** @var Tracer $tracer */
         return $tracer;
     }
@@ -69,9 +69,9 @@ class ComponentTestCaseBase extends TestCaseBase
     protected static function buildResourcesClientForAppCode(): ResourcesClient
     {
         $resCleanerId = AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerSpawnedProcessInternalId;
-        TestCase::assertNotNull($resCleanerId);
+        Assert::assertNotNull($resCleanerId);
         $resCleanerPort = AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerPort;
-        TestCase::assertNotNull($resCleanerPort);
+        Assert::assertNotNull($resCleanerPort);
         return new ResourcesClient($resCleanerId, $resCleanerPort);
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/ComponentTestsPhpUnitExtension.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ComponentTestsPhpUnitExtension.php
@@ -35,7 +35,7 @@ use Elastic\Apm\Impl\NoopTracer;
 use Elastic\Apm\Impl\Util\TimeUtil;
 use ElasticApmTests\Util\LogCategoryForTests;
 use ElasticApmTests\Util\PhpUnitExtensionBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Runner\AfterIncompleteTestHook;
 use PHPUnit\Runner\AfterRiskyTestHook;
 use PHPUnit\Runner\AfterSkippedTestHook;
@@ -93,7 +93,7 @@ final class ComponentTestsPhpUnitExtension extends PhpUnitExtensionBase implemen
                 true /* <- shouldCaptureStdOutErr */,
                 0 /* <- expectedExitCode */
             );
-            TestCase::assertSame(0, $exitCode);
+            Assert::assertSame(0, $exitCode);
         }
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))

--- a/tests/ElasticApmTests/ComponentTests/Util/CurlHandleWrappedForTests.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/CurlHandleWrappedForTests.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\ComponentTests\Util;
 use Elastic\Apm\Impl\AutoInstrument\CurlHandleWrappedTrait;
 use Elastic\Apm\Impl\Log\LoggableInterface;
 use Elastic\Apm\Impl\Log\LoggableToString;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class CurlHandleWrappedForTests implements LoggableInterface
 {
@@ -65,14 +65,14 @@ final class CurlHandleWrappedForTests implements LoggableInterface
         $hasVerboseOutputWritten = false;
         try {
             $verboseOutputFile = fopen($this->tempFileForVerboseOutput, 'w'); // open file for write
-            TestCase::assertIsResource($verboseOutputFile, $assertMsg);
+            Assert::assertIsResource($verboseOutputFile, $assertMsg);
             $this->setOpt(CURLOPT_STDERR, $verboseOutputFile);
             $retVal = curl_exec($this->curlHandle); // @phpstan-ignore-line
         } finally {
             if ($verboseOutputFile !== null) {
-                TestCase::assertIsResource($verboseOutputFile, $assertMsg);
-                TestCase::assertTrue(fflush($verboseOutputFile), $assertMsg);
-                TestCase::assertTrue(fclose($verboseOutputFile), $assertMsg);
+                Assert::assertIsResource($verboseOutputFile, $assertMsg);
+                Assert::assertTrue(fflush($verboseOutputFile), $assertMsg);
+                Assert::assertTrue(fclose($verboseOutputFile), $assertMsg);
                 $verboseOutputFile = null;
                 $hasVerboseOutputWritten = true;
             }
@@ -80,11 +80,11 @@ final class CurlHandleWrappedForTests implements LoggableInterface
 
         if ($hasVerboseOutputWritten) {
             $verboseOutput = file_get_contents($this->tempFileForVerboseOutput);
-            TestCase::assertIsString($verboseOutput, $assertMsg);
+            Assert::assertIsString($verboseOutput, $assertMsg);
             $this->lastVerboseOutput = $verboseOutput;
         }
 
-        TestCase::assertNotNull($retVal, $assertMsg);
+        Assert::assertNotNull($retVal, $assertMsg);
         return $retVal;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/DataFromAgentPlusRawAccumulator.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/DataFromAgentPlusRawAccumulator.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Log\LoggableTrait;
 use Elastic\Apm\Impl\Log\Logger;
 use ElasticApmTests\Util\Deserialization\SerializedEventSinkTrait;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class DataFromAgentPlusRawAccumulator implements LoggableInterface
 {
@@ -71,10 +71,10 @@ final class DataFromAgentPlusRawAccumulator implements LoggableInterface
     {
         foreach ($intakeApiRequests as $intakeApiRequest) {
             $dataFromAgent = IntakeApiRequestDeserializer::deserialize($intakeApiRequest);
-            TestCase::assertCount(1, $dataFromAgent->metadatas);
+            Assert::assertCount(1, $dataFromAgent->metadatas);
             $metadata = $dataFromAgent->metadatas[0];
-            TestCase::assertNotNull($metadata->service->agent);
-            TestCase::assertNotNull(
+            Assert::assertNotNull($metadata->service->agent);
+            Assert::assertNotNull(
                 $metadata->service->agent->ephemeralId,
                 LoggableToString::convert(
                     [
@@ -86,8 +86,8 @@ final class DataFromAgentPlusRawAccumulator implements LoggableInterface
             $intakeApiRequest->agentEphemeralId = $metadata->service->agent->ephemeralId;
             $this->result->intakeApiRequests[] = $intakeApiRequest;
             foreach (get_object_vars($dataFromAgent) as $propName => $propValue) {
-                TestCase::assertIsArray($propValue);
-                TestCase::assertIsArray($this->result->$propName);
+                Assert::assertIsArray($propValue);
+                Assert::assertIsArray($this->result->$propName);
                 $this->result->$propName = array_merge($this->result->$propName, $propValue);
             }
         }

--- a/tests/ElasticApmTests/ComponentTests/Util/DataFromAgentPlusRawValidator.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/DataFromAgentPlusRawValidator.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Tracer;
 use ElasticApmTests\Util\DataFromAgentValidator;
 use ElasticApmTests\Util\AssertValidTrait;
 use ElasticApmTests\Util\MetadataValidator;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class DataFromAgentPlusRawValidator
 {
@@ -79,7 +79,7 @@ final class DataFromAgentPlusRawValidator
                 return $appCodeHostParams;
             }
         }
-        TestCase::fail(
+        Assert::fail(
             'AppCodeHostParams with spawnedProcessInternalId `' . $spawnedProcessInternalId . '\' not found'
         );
     }
@@ -123,11 +123,11 @@ final class DataFromAgentPlusRawValidator
             : "ApiKey $configuredApiKey";
 
         if ($expectedAuthHeaderValue === null) {
-            TestCase::assertArrayNotHasKey(self::AUTH_HTTP_HEADER_NAME, $headers);
+            Assert::assertArrayNotHasKey(self::AUTH_HTTP_HEADER_NAME, $headers);
         } else {
             $actualAuthHeaderValue = $headers[self::AUTH_HTTP_HEADER_NAME];
-            TestCase::assertCount(1, $actualAuthHeaderValue);
-            TestCase::assertSame($expectedAuthHeaderValue, $actualAuthHeaderValue[0]);
+            Assert::assertCount(1, $actualAuthHeaderValue);
+            Assert::assertSame($expectedAuthHeaderValue, $actualAuthHeaderValue[0]);
         }
     }
 
@@ -156,7 +156,7 @@ final class DataFromAgentPlusRawValidator
         array $headers
     ): void {
         $actualHeaderValue = $headers[self::USER_AGENT_HTTP_HEADER_NAME];
-        TestCase::assertCount(1, $actualHeaderValue);
-        TestCase::assertSame($expectedHeaderValue, $actualHeaderValue[0]);
+        Assert::assertCount(1, $actualHeaderValue);
+        Assert::assertSame($expectedHeaderValue, $actualHeaderValue[0]);
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/ExpectedEventCounts.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ExpectedEventCounts.php
@@ -28,7 +28,7 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Log\LoggableTrait;
 use Elastic\Apm\Impl\Util\ArrayUtil;
 use ElasticApmTests\Util\TestCaseBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class ExpectedEventCounts implements LoggableInterface
 {
@@ -97,7 +97,7 @@ final class ExpectedEventCounts implements LoggableInterface
         }
 
         if ($apmDataKind === ApmDataKind::span() && $this->maxSpanCount !== null) {
-            TestCase::assertLessThanOrEqual($this->maxSpanCount, $actualCount, $dbgCtxStr);
+            Assert::assertLessThanOrEqual($this->maxSpanCount, $actualCount, $dbgCtxStr);
             return $expectedCount <= $actualCount;
         }
 
@@ -105,7 +105,7 @@ final class ExpectedEventCounts implements LoggableInterface
             return $expectedCount <= $actualCount;
         }
 
-        TestCase::assertLessThanOrEqual($expectedCount, $actualCount, $dbgCtxStr);
+        Assert::assertLessThanOrEqual($expectedCount, $actualCount, $dbgCtxStr);
         return $expectedCount === $actualCount;
     }
 }

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpAppCodeHostHandle.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpAppCodeHostHandle.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\Util\ClassNameUtil;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class HttpAppCodeHostHandle extends AppCodeHostHandle
 {
@@ -100,7 +100,7 @@ class HttpAppCodeHostHandle extends AppCodeHostHandle
         $this->afterAppCodeInvocation($appCodeInvocation);
 
         if ($requestParams->expectedHttpResponseStatusCode !== null) {
-            TestCase::assertSame(
+            Assert::assertSame(
                 $requestParams->expectedHttpResponseStatusCode,
                 $response->getStatusCode(),
                 LoggableToString::convert(

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpClientUtilForTests.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpClientUtilForTests.php
@@ -34,7 +34,7 @@ use ElasticApmTests\Util\SourceClassLogContext;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 
 final class HttpClientUtilForTests
@@ -146,7 +146,7 @@ final class HttpClientUtilForTests
         ResourcesClient $resourcesClient
     ): CurlHandleWrappedForTests {
         $curlInitRetVal = curl_init(UrlUtil::buildFullUrl($urlParts));
-        TestCase::assertNotSame(false, $curlInitRetVal);
+        Assert::assertNotSame(false, $curlInitRetVal);
         $curlHandle = new CurlHandleWrappedForTests($resourcesClient, $curlInitRetVal);
         $dataPerRequestHeaderName = RequestHeadersRawSnapshotSource::optionNameToHeaderName(
             AllComponentTestsOptionsMetadata::DATA_PER_REQUEST_OPTION_NAME

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerHandle.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerHandle.php
@@ -28,7 +28,7 @@ use Elastic\Apm\Impl\Log\LoggableTrait;
 use Elastic\Apm\Impl\Util\JsonUtil;
 use Elastic\Apm\Impl\Util\UrlParts;
 use GuzzleHttp\Exception\GuzzleException;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpServerHandle implements LoggableInterface
@@ -103,14 +103,14 @@ class HttpServerHandle implements LoggableInterface
             HttpConstantsForTests::METHOD_POST,
             TestInfraHttpServerProcessBase::EXIT_URI_PATH
         );
-        TestCase::assertSame(HttpConstantsForTests::STATUS_OK, $response->getStatusCode());
+        Assert::assertSame(HttpConstantsForTests::STATUS_OK, $response->getStatusCode());
 
         $hasExited = ProcessUtilForTests::waitForProcessToExit(
             $this->dbgServerDesc,
             $this->spawnedProcessOsId,
             10 * 1000 * 1000 /* <- maxWaitTimeInMicroseconds - 10 seconds */
         );
-        TestCase::assertTrue($hasExited);
+        Assert::assertTrue($hasExited);
     }
 
     public function serialize(): string
@@ -121,17 +121,17 @@ class HttpServerHandle implements LoggableInterface
     public static function deserialize(string $serialized): HttpServerHandle
     {
         $decodeJson = JsonUtil::decode($serialized, /* asAssocArray: */ true);
-        TestCase::assertIsArray($decodeJson);
+        Assert::assertIsArray($decodeJson);
 
         $getDecodedIntValue = function (string $propName) use ($decodeJson): int {
-            TestCase::assertArrayHasKey($propName, $decodeJson);
-            TestCase::assertIsInt($decodeJson[$propName]);
+            Assert::assertArrayHasKey($propName, $decodeJson);
+            Assert::assertIsInt($decodeJson[$propName]);
             return $decodeJson[$propName];
         };
 
         $getDecodedStringValue = function (string $propName) use ($decodeJson): string {
-            TestCase::assertArrayHasKey($propName, $decodeJson);
-            TestCase::assertIsString($decodeJson[$propName]);
+            Assert::assertArrayHasKey($propName, $decodeJson);
+            Assert::assertIsString($decodeJson[$propName]);
             return $decodeJson[$propName];
         };
 

--- a/tests/ElasticApmTests/ComponentTests/Util/HttpServerStarter.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/HttpServerStarter.php
@@ -31,7 +31,7 @@ use Elastic\Apm\Impl\Util\JsonUtil;
 use Elastic\Apm\Impl\Util\UrlParts;
 use ElasticApmTests\Util\ArrayUtilForTests;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 use Throwable;
 
@@ -158,7 +158,7 @@ abstract class HttpServerStarter
             }
             $candidate = $calcNextInCircularPortRange($candidate);
             if ($candidate === $portToStartSearchFrom) {
-                TestCase::fail(
+                Assert::fail(
                     'Could not find a free port'
                     . LoggableToString::convert(
                         [
@@ -208,9 +208,9 @@ abstract class HttpServerStarter
 
                 /** @var array<string, mixed> $decodedBody */
                 $decodedBody = JsonUtil::decode($response->getBody()->getContents(), /* asAssocArray */ true);
-                TestCase::assertArrayHasKey(HttpServerHandle::PID_KEY, $decodedBody);
+                Assert::assertArrayHasKey(HttpServerHandle::PID_KEY, $decodedBody);
                 $receivedPid = $decodedBody[HttpServerHandle::PID_KEY];
-                TestCase::assertIsInt($receivedPid, LoggableToString::convert(['$decodedBody' => $decodedBody]));
+                Assert::assertIsInt($receivedPid, LoggableToString::convert(['$decodedBody' => $decodedBody]));
                 $pid = $receivedPid;
 
                 ($loggerProxy = $logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))

--- a/tests/ElasticApmTests/ComponentTests/Util/IntakeApiRequestDeserializer.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/IntakeApiRequestDeserializer.php
@@ -33,7 +33,7 @@ use ElasticApmTests\Util\DataFromAgent;
 use ElasticApmTests\Util\Deserialization\SerializedEventSinkTrait;
 use ElasticApmTests\Util\LogCategoryForTests;
 use ElasticApmTests\Util\TextUtilForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class IntakeApiRequestDeserializer implements LoggableInterface
 {
@@ -80,14 +80,14 @@ final class IntakeApiRequestDeserializer implements LoggableInterface
                 continue;
             }
             // empty line can only be the last one
-            TestCase::assertFalse($encounteredEmptyLine);
+            Assert::assertFalse($encounteredEmptyLine);
 
             ($loggerProxy = $this->logger->ifTraceLevelEnabled(__LINE__, __FUNCTION__))
             && $loggerProxy->log('Processing a line from intake API request', ['bodyLine' => $bodyLine]);
 
             $lineDecodedJson = JsonUtil::decode($bodyLine, /* asAssocArray */ true);
-            TestCase::assertIsArray($lineDecodedJson);
-            TestCase::assertCount(
+            Assert::assertIsArray($lineDecodedJson);
+            Assert::assertCount(
                 1,
                 $lineDecodedJson,
                 'Each decoded line should have exactly one top level key.' . " bodyLine: `$bodyLine'"
@@ -96,7 +96,7 @@ final class IntakeApiRequestDeserializer implements LoggableInterface
             $linePayloadDecodedJson = $lineDecodedJson[$linePayloadType];
 
             // metadata is the first line and only the first line
-            TestCase::assertSame($isFirstLine, 'metadata' === $linePayloadType);
+            Assert::assertSame($isFirstLine, 'metadata' === $linePayloadType);
 
             $linePayloadEncodedJson = self::decodedJsonToString($linePayloadDecodedJson);
 
@@ -117,12 +117,12 @@ final class IntakeApiRequestDeserializer implements LoggableInterface
                     $this->addSpan($linePayloadEncodedJson);
                     break;
                 default:
-                    TestCase::fail('Unexpected event kind `' . $linePayloadType . '\'.' . " bodyLine: `$bodyLine'");
+                    Assert::fail('Unexpected event kind `' . $linePayloadType . '\'.' . " bodyLine: `$bodyLine'");
             }
             $isFirstLine = false;
         }
 
-        TestCase::assertCount(1, $this->result->metadatas);
+        Assert::assertCount(1, $this->result->metadatas);
         return $this->result;
     }
 
@@ -134,14 +134,14 @@ final class IntakeApiRequestDeserializer implements LoggableInterface
     private function addTransaction(string $encodedJson): void
     {
         $newTransaction = $this->validateAndDeserializeTransaction($encodedJson);
-        TestCase::assertNull($this->result->executionSegmentByIdOrNull($newTransaction->id));
+        Assert::assertNull($this->result->executionSegmentByIdOrNull($newTransaction->id));
         $this->result->idToTransaction[$newTransaction->id] = $newTransaction;
     }
 
     private function addSpan(string $encodedJson): void
     {
         $newSpan = $this->validateAndDeserializeSpan($encodedJson);
-        TestCase::assertNull($this->result->executionSegmentByIdOrNull($newSpan->id));
+        Assert::assertNull($this->result->executionSegmentByIdOrNull($newSpan->id));
         $this->result->idToSpan[$newSpan->id] = $newSpan;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/MockApmServer.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/MockApmServer.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\Util\JsonUtil;
 use Elastic\Apm\Impl\Util\NumericUtil;
 use Elastic\Apm\Impl\Util\TextUtil;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
@@ -92,7 +92,7 @@ final class MockApmServer extends TestInfraHttpServerProcessBase
 
     private function processIntakeApiRequest(ServerRequestInterface $request): ResponseInterface
     {
-        TestCase::assertNotNull($this->reactLoop);
+        Assert::assertNotNull($this->reactLoop);
 
         if ($request->getBody()->getSize() === 0) {
             return $this->buildIntakeApiErrorResponse(
@@ -159,7 +159,7 @@ final class MockApmServer extends TestInfraHttpServerProcessBase
         return new Promise(
             function ($resolve) use ($fromIndex) {
                 $pendingDataRequestId = self::$pendingDataRequestNextId++;
-                TestCase::assertNotNull($this->reactLoop);
+                Assert::assertNotNull($this->reactLoop);
                 $timer = $this->reactLoop->addTimer(
                     self::DATA_FROM_AGENT_MAX_WAIT_TIME_SECONDS,
                     function () use ($pendingDataRequestId) {
@@ -241,7 +241,7 @@ final class MockApmServer extends TestInfraHttpServerProcessBase
     /** @inheritDoc */
     protected function exit(): void
     {
-        TestCase::assertNotNull($this->reactLoop);
+        Assert::assertNotNull($this->reactLoop);
 
         foreach ($this->pendingDataRequests as $pendingDataRequest) {
             $this->reactLoop->cancelTimer($pendingDataRequest->timer);

--- a/tests/ElasticApmTests/ComponentTests/Util/ProcessUtilForTests.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ProcessUtilForTests.php
@@ -28,7 +28,7 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Util\ExceptionUtil;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 
 final class ProcessUtilForTests
@@ -101,7 +101,7 @@ final class ProcessUtilForTests
             $tempOutputFilePath = tempnam(sys_get_temp_dir(), '');
             $tempOutputFilePath .= '_' . str_replace('\\', '_', __CLASS__) . '_stdout+stderr.txt';
             if (file_exists($tempOutputFilePath)) {
-                TestCase::assertTrue(unlink($tempOutputFilePath));
+                Assert::assertTrue(unlink($tempOutputFilePath));
             }
             $descriptorSpec[1] = [self::PROC_OPEN_DESCRIPTOR_FILE_TYPE, $tempOutputFilePath, "w"]; // 1 - stdout
             $descriptorSpec[2] = [self::PROC_OPEN_DESCRIPTOR_FILE_TYPE, $tempOutputFilePath, "w"]; // 2 - stderr
@@ -135,7 +135,7 @@ final class ProcessUtilForTests
             && $loggerProxy->log($cmd . ' exited', $logCtx);
 
             if ($expectedExitCode !== null && $hasReturnedExitCode) {
-                TestCase::assertSame($expectedExitCode, $exitCode, LoggableToString::convert($logCtx));
+                Assert::assertSame($expectedExitCode, $exitCode, LoggableToString::convert($logCtx));
             }
         }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/ResourcesCleaner.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/ResourcesCleaner.php
@@ -27,7 +27,7 @@ use Ds\Set;
 use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Log\Logger;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\TimerInterface;
@@ -71,7 +71,7 @@ final class ResourcesCleaner extends TestInfraHttpServerProcessBase
     {
         parent::processConfig();
 
-        TestCase::assertTrue(
+        Assert::assertTrue(
             isset(AmbientContextForTests::testConfig()->dataPerProcess->rootProcessId), // @phpstan-ignore-line
             LoggableToString::convert(AmbientContextForTests::testConfig())
         );
@@ -80,7 +80,7 @@ final class ResourcesCleaner extends TestInfraHttpServerProcessBase
     /** @inheritDoc */
     protected function beforeLoopRun(): void
     {
-        TestCase::assertNotNull($this->reactLoop);
+        Assert::assertNotNull($this->reactLoop);
         $this->parentProcessTrackingTimer = $this->reactLoop->addPeriodicTimer(
             1 /* interval in seconds */,
             function () {
@@ -100,8 +100,8 @@ final class ResourcesCleaner extends TestInfraHttpServerProcessBase
         $this->cleanSpawnedProcesses();
         $this->cleanFiles();
 
-        TestCase::assertNotNull($this->reactLoop);
-        TestCase::assertNotNull($this->parentProcessTrackingTimer);
+        Assert::assertNotNull($this->reactLoop);
+        Assert::assertNotNull($this->parentProcessTrackingTimer);
         $this->reactLoop->cancelTimer($this->parentProcessTrackingTimer);
 
         parent::exit();

--- a/tests/ElasticApmTests/ComponentTests/Util/SpawnedProcessBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/SpawnedProcessBase.php
@@ -36,7 +36,7 @@ use Elastic\Apm\Impl\Util\ClassNameUtil;
 use Elastic\Apm\Impl\Util\ExceptionUtil;
 use Elastic\Apm\Impl\Util\UrlParts;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 use Throwable;
 
@@ -77,11 +77,11 @@ abstract class SpawnedProcessBase implements LoggableInterface
     {
         self::getRequiredTestOption(AllComponentTestsOptionsMetadata::DATA_PER_PROCESS_OPTION_NAME);
         if ($this->shouldRegisterThisProcessWithResourcesCleaner()) {
-            TestCase::assertNotNull(
+            Assert::assertNotNull(
                 AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerSpawnedProcessInternalId,
                 LoggableToString::convert(AmbientContextForTests::testConfig())
             );
-            TestCase::assertNotNull(
+            Assert::assertNotNull(
                 AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerPort,
                 LoggableToString::convert(AmbientContextForTests::testConfig())
             );
@@ -99,7 +99,7 @@ abstract class SpawnedProcessBase implements LoggableInterface
 
         try {
             $dbgProcessName = getenv(self::DBG_PROCESS_NAME_ENV_VAR_NAME);
-            TestCase::assertIsString($dbgProcessName);
+            Assert::assertIsString($dbgProcessName);
             AmbientContextForTests::init($dbgProcessName);
             $thisObj = new static(); // @phpstan-ignore-line
 
@@ -185,9 +185,9 @@ abstract class SpawnedProcessBase implements LoggableInterface
             'Registering with ' . ClassNameUtil::fqToShort(ResourcesCleaner::class) . '...'
         );
 
-        TestCase::assertNotNull(AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerPort);
+        Assert::assertNotNull(AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerPort);
         $resCleanerId = AmbientContextForTests::testConfig()->dataPerProcess->resourcesCleanerSpawnedProcessInternalId;
-        TestCase::assertNotNull($resCleanerId);
+        Assert::assertNotNull($resCleanerId);
         $response = HttpClientUtilForTests::sendRequest(
             HttpConstantsForTests::METHOD_POST,
             (new UrlParts())

--- a/tests/ElasticApmTests/ComponentTests/Util/SyslogClearer.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/SyslogClearer.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\ComponentTests\Util;
 use Elastic\Apm\Impl\Log\LoggableToString;
 use ElasticApmTests\TestsRootDir;
 use ElasticApmTests\Util\FileUtilForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -38,7 +38,7 @@ final class SyslogClearer extends TestInfraHttpServerProcessBase
     {
         parent::processConfig();
 
-        TestCase::assertTrue(
+        Assert::assertTrue(
             isset(AmbientContextForTests::testConfig()->dataPerProcess->rootProcessId), // @phpstan-ignore-line
             LoggableToString::convert(AmbientContextForTests::testConfig())
         );

--- a/tests/ElasticApmTests/ComponentTests/Util/SyslogClearerClient.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/SyslogClearerClient.php
@@ -28,7 +28,7 @@ use Elastic\Apm\Impl\Log\Logger;
 use Elastic\Apm\Impl\Util\ClassNameUtil;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SyslogClearerClient
 {
@@ -36,7 +36,7 @@ final class SyslogClearerClient
 
     public static function assertRunningAsRoot(): void
     {
-        TestCase::assertSame(
+        Assert::assertSame(
             0,
             posix_geteuid(),
             LoggableToString::convert(
@@ -77,7 +77,7 @@ final class SyslogClearerClient
             HttpConstantsForTests::METHOD_POST,
             SyslogClearer::CLEAR_SYSLOG_URI_PATH
         );
-        TestCase::assertSame(HttpConstantsForTests::STATUS_OK, $response->getStatusCode());
+        Assert::assertSame(HttpConstantsForTests::STATUS_OK, $response->getStatusCode());
 
         ($loggerProxy = $localLogger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
         && $loggerProxy->log('Exiting...');
@@ -98,7 +98,7 @@ final class SyslogClearerClient
     private static function clientInit(string $dbgEntryMethod): Logger
     {
         global $argv;
-        TestCase::assertGreaterThanOrEqual(1, count($argv), LoggableToString::convert(['argv' => $argv]));
+        Assert::assertGreaterThanOrEqual(1, count($argv), LoggableToString::convert(['argv' => $argv]));
         AmbientContextForTests::init(ClassNameUtil::fqToShort(self::class) . '::' . $dbgEntryMethod);
 
         $localLogger = AmbientContextForTests::loggerFactory()->loggerForClass(
@@ -117,7 +117,7 @@ final class SyslogClearerClient
     private static function deserializeHttpServerHandleFromArgs(Logger $logger): HttpServerHandle
     {
         global $argv;
-        TestCase::assertGreaterThanOrEqual(2, count($argv), LoggableToString::convert(['argv' => $argv]));
+        Assert::assertGreaterThanOrEqual(2, count($argv), LoggableToString::convert(['argv' => $argv]));
 
         $httpServerHandle = HttpServerHandle::deserialize($argv[1]);
 

--- a/tests/ElasticApmTests/ComponentTests/Util/TestCaseHandle.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestCaseHandle.php
@@ -33,7 +33,7 @@ use Elastic\Apm\Impl\Util\ClassNameUtil;
 use Elastic\Apm\Impl\Util\TimeUtil;
 use ElasticApmTests\Util\ArrayUtilForTests;
 use ElasticApmTests\Util\LogCategoryForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 
 final class TestCaseHandle implements LoggableInterface
@@ -107,16 +107,16 @@ final class TestCaseHandle implements LoggableInterface
      */
     public function ensureMainHttpAppCodeHost(?Closure $setParamsFunc = null): HttpAppCodeHostHandle
     {
-        TestCase::assertTrue(ComponentTestCaseBase::isMainAppCodeHostHttp());
+        Assert::assertTrue(ComponentTestCaseBase::isMainAppCodeHostHttp());
         $appCodeHostHandle = $this->ensureMainAppCodeHost(
             function (AppCodeHostParams $appCodeHostParams) use ($setParamsFunc): void {
-                TestCase::assertInstanceOf(HttpAppCodeHostParams::class, $appCodeHostParams);
+                Assert::assertInstanceOf(HttpAppCodeHostParams::class, $appCodeHostParams);
                 if ($setParamsFunc !== null) {
                     $setParamsFunc($appCodeHostParams);
                 }
             }
         );
-        TestCase::assertInstanceOf(HttpAppCodeHostHandle::class, $appCodeHostHandle);
+        Assert::assertInstanceOf(HttpAppCodeHostHandle::class, $appCodeHostHandle);
         return $appCodeHostHandle;
     }
 
@@ -145,7 +145,7 @@ final class TestCaseHandle implements LoggableInterface
         ExpectedEventCounts $expectedEventCounts,
         bool $shouldValidate = true
     ): DataFromAgentPlusRaw {
-        TestCase::assertNotNull($this->appCodeInvocation);
+        Assert::assertNotNull($this->appCodeInvocation);
         $dataFromAgentAccumulator = new DataFromAgentPlusRawAccumulator();
         $hasPassed = (new PollingCheck(
             __FUNCTION__ . ' passes',
@@ -155,7 +155,7 @@ final class TestCaseHandle implements LoggableInterface
                 return $this->pollForDataFromAgent($expectedEventCounts, $dataFromAgentAccumulator);
             }
         );
-        TestCase::assertTrue(
+        Assert::assertTrue(
             $hasPassed,
             'The expected data from agent has not arrived.'
             . ' ' . LoggableToString::convert(
@@ -201,7 +201,7 @@ final class TestCaseHandle implements LoggableInterface
 
     public function setAppCodeInvocation(AppCodeInvocation $appCodeInvocation): void
     {
-        TestCase::assertNull($this->appCodeInvocation);
+        Assert::assertNull($this->appCodeInvocation);
         $appCodeInvocation->appCodeHostsParams = [];
         if ($this->mainAppCodeHost !== null) {
             $appCodeInvocation->appCodeHostsParams[] = $this->mainAppCodeHost->appCodeHostParams;
@@ -222,7 +222,7 @@ final class TestCaseHandle implements LoggableInterface
 
     private function addPortInUse(int $port): void
     {
-        TestCase::assertNotContains($port, $this->portsInUse);
+        Assert::assertNotContains($port, $this->portsInUse);
         $this->portsInUse[] = $port;
     }
 

--- a/tests/ElasticApmTests/ComponentTests/Util/TestInfraDataPerRequest.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestInfraDataPerRequest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace ElasticApmTests\ComponentTests\Util;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class TestInfraDataPerRequest extends TestInfraData
 {
@@ -56,7 +56,7 @@ final class TestInfraDataPerRequest extends TestInfraData
                     return null;
                 }
                 $appCodeTarget = new AppCodeTarget();
-                TestCase::assertIsArray($decodedJson);
+                Assert::assertIsArray($decodedJson);
                 $appCodeTarget->deserializeFromDecodedJson($decodedJson);
                 return $appCodeTarget;
             default:

--- a/tests/ElasticApmTests/ComponentTests/Util/TestInfraHttpServerProcessBase.php
+++ b/tests/ElasticApmTests/ComponentTests/Util/TestInfraHttpServerProcessBase.php
@@ -32,7 +32,7 @@ use Elastic\Apm\Impl\Util\ExceptionUtil;
 use ElasticApmTests\Util\LogCategoryForTests;
 use ErrorException;
 use Exception;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
@@ -92,13 +92,13 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
     {
         parent::processConfig();
 
-        TestCase::assertNotNull(
+        Assert::assertNotNull(
             AmbientContextForTests::testConfig()->dataPerProcess->thisServerPort,
             LoggableToString::convert(AmbientContextForTests::testConfig())
         );
 
         // At this point request is not parsed and applied to config yet
-        TestCase::assertNull(AmbientContextForTests::testConfig()->dataPerRequest);
+        Assert::assertNull(AmbientContextForTests::testConfig()->dataPerRequest);
     }
 
     /**
@@ -132,7 +132,7 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
     {
         $this->reactLoop = Loop::get();
         $thisServerPort = AmbientContextForTests::testConfig()->dataPerProcess->thisServerPort;
-        TestCase::assertNotNull($thisServerPort);
+        Assert::assertNotNull($thisServerPort);
         $uri = HttpServerHandle::DEFAULT_HOST . ':' . $thisServerPort;
         $this->serverSocket = new SocketServer($uri, /* context */ [], $this->reactLoop);
         $httpServer = new HttpServer(
@@ -155,7 +155,7 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
 
         $this->beforeLoopRun();
 
-        TestCase::assertNotNull($this->reactLoop);
+        Assert::assertNotNull($this->reactLoop);
         $this->reactLoop->run();
     }
 
@@ -200,7 +200,7 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
                     ]
                 );
             } else {
-                TestCase::assertInstanceOf(Promise::class, $response);
+                Assert::assertInstanceOf(Promise::class, $response);
 
                 ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))
                 && $loggerProxy->log('Promise returned - response will be returned later...');
@@ -233,7 +233,7 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
                 ),
                 AmbientContextForTests::loggerFactory()
             );
-            TestCase::assertNotNull($testConfigForRequest->dataPerRequest);
+            Assert::assertNotNull($testConfigForRequest->dataPerRequest);
             $verifySpawnedProcessInternalIdResponse = self::verifySpawnedProcessInternalId(
                 $testConfigForRequest->dataPerRequest->spawnedProcessInternalId
             );
@@ -261,7 +261,7 @@ abstract class TestInfraHttpServerProcessBase extends SpawnedProcessBase
      */
     protected function exit(): void
     {
-        TestCase::assertNotNull($this->serverSocket);
+        Assert::assertNotNull($this->serverSocket);
         $this->serverSocket->close();
 
         ($loggerProxy = $this->logger->ifDebugLevelEnabled(__LINE__, __FUNCTION__))

--- a/tests/ElasticApmTests/ComponentTests/appCodeForTestCaughtExceptionResponded500.php
+++ b/tests/ElasticApmTests/ComponentTests/appCodeForTestCaughtExceptionResponded500.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\ComponentTests;
 use ElasticApmTests\ComponentTests\Util\HttpConstantsForTests;
 use ElasticApmTests\Util\DummyExceptionForTests;
 use Exception;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Throwable;
 
 const APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_MESSAGE = 'Message for caught exception responded 500';
@@ -48,7 +48,7 @@ function appCodeForTestCaughtExceptionResponded500Impl(): void
 
     $message = APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_MESSAGE;
     $code = APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_CODE;
-    TestCase::assertSame(APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_THROW_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_THROW_LINE_NUMBER, __LINE__ + 1);
     throw new DummyExceptionForTests($message, $code);
 }
 
@@ -56,7 +56,7 @@ const APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_CALL_TO_IMPL_LINE_NUMBER 
 
 function appCodeForTestCaughtExceptionResponded500(): void
 {
-    TestCase::assertSame(APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 2);
+    Assert::assertSame(APP_CODE_FOR_TEST_CAUGHT_EXCEPTION_RESPONDED_500_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 2);
     try {
         appCodeForTestCaughtExceptionResponded500Impl();
     } catch (Throwable $throwable) {

--- a/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUncaughtException.php
+++ b/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUncaughtException.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\ComponentTests;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Throwable;
 
 const APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_MESSAGE = 'Message for uncaught exception';
@@ -43,7 +43,7 @@ function appCodeForTestPhpErrorUncaughtExceptionImpl(): void
     } catch (Throwable $throwable) {
     }
 
-    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_ERROR_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_ERROR_LINE_NUMBER, __LINE__ + 1);
     throw new Exception(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_MESSAGE);
 }
 
@@ -51,6 +51,6 @@ const APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_CALL_TO_IMPL_LINE_NUMBER = 
 
 function appCodeForTestPhpErrorUncaughtException(): void
 {
-    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
     appCodeForTestPhpErrorUncaughtExceptionImpl();
 }

--- a/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUndefinedVariable.php
+++ b/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUndefinedVariable.php
@@ -23,20 +23,20 @@ declare(strict_types=1);
 
 namespace ElasticApmTests\ComponentTests;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 const APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_ERROR_LINE_NUMBER = 35;
 const APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_CALL_TO_IMPL_LINE_NUMBER = 41;
 
 function appCodeForTestPhpErrorUndefinedVariableImpl(): void
 {
-    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_ERROR_LINE_NUMBER, __LINE__ + 2);
+    Assert::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_ERROR_LINE_NUMBER, __LINE__ + 2);
     /** @noinspection PhpUndefinedVariableInspection, PhpUnusedLocalVariableInspection */
     $undefinedVariable = $undefinedVariable + 1; // @phpstan-ignore-line
 }
 
 function appCodeForTestPhpErrorUndefinedVariable(): void
 {
-    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNDEFINED_VARIABLE_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
     appCodeForTestPhpErrorUndefinedVariableImpl();
 }

--- a/tests/ElasticApmTests/TestsSharedCode/SamplingTestSharedCode.php
+++ b/tests/ElasticApmTests/TestsSharedCode/SamplingTestSharedCode.php
@@ -28,7 +28,7 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 use ElasticApmTests\Util\DataFromAgent;
 use ElasticApmTests\Util\TestCaseBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SamplingTestSharedCode
 {
@@ -47,7 +47,7 @@ final class SamplingTestSharedCode
         $tx = ElasticApm::getCurrentTransaction();
         $expectedIsSampled = $transactionSampleRate === 1.0 ? true : ($transactionSampleRate === 0.0 ? false : null);
         if ($expectedIsSampled !== null) {
-            TestCase::assertSame(
+            Assert::assertSame(
                 $expectedIsSampled,
                 $tx->isSampled(),
                 LoggableToString::convert(['transactionSampleRate' => $transactionSampleRate])
@@ -76,18 +76,18 @@ final class SamplingTestSharedCode
         $tx = $eventsFromAgent->singleTransaction();
         $transactionSampleRate = $inputTransactionSampleRate ?? 1.0;
         if ($transactionSampleRate === 1.0) {
-            TestCase::assertTrue($tx->isSampled);
+            Assert::assertTrue($tx->isSampled);
         } elseif ($transactionSampleRate === 0.0) {
-            TestCase::assertFalse($tx->isSampled);
+            Assert::assertFalse($tx->isSampled);
         }
 
         if ($tx->isSampled) {
-            TestCase::assertCount(2, $eventsFromAgent->idToSpan);
+            Assert::assertCount(2, $eventsFromAgent->idToSpan);
             // Started and dropped spans should be counted only for sampled transactions
-            TestCase::assertSame(2, $tx->startedSpansCount);
+            Assert::assertSame(2, $tx->startedSpansCount);
 
             TestCaseBase::assertLabelsCount(1, $tx);
-            TestCase::assertSame(123, TestCaseBase::getLabel($tx, 'TX_label_key'));
+            Assert::assertSame(123, TestCaseBase::getLabel($tx, 'TX_label_key'));
 
             TestCaseBase::assertSame($transactionSampleRate, $tx->sampleRate);
             foreach ($eventsFromAgent->idToSpan as $span) {
@@ -101,14 +101,14 @@ final class SamplingTestSharedCode
              * No spans should be captured.
              */
 
-            TestCase::assertEmpty($eventsFromAgent->idToSpan);
+            Assert::assertEmpty($eventsFromAgent->idToSpan);
             // Started and dropped spans should be counted only for sampled transactions
-            TestCase::assertSame(0, $tx->startedSpansCount);
+            Assert::assertSame(0, $tx->startedSpansCount);
 
-            TestCase::assertNull($tx->context);
+            Assert::assertNull($tx->context);
 
             TestCaseBase::assertSame(0.0, $tx->sampleRate);
         }
-        TestCase::assertSame(0, $tx->droppedSpansCount);
+        Assert::assertSame(0, $tx->droppedSpansCount);
     }
 }

--- a/tests/ElasticApmTests/TestsSharedCode/StackTraceTestSharedCode.php
+++ b/tests/ElasticApmTests/TestsSharedCode/StackTraceTestSharedCode.php
@@ -30,7 +30,7 @@ use Elastic\Apm\SpanInterface;
 use Elastic\Apm\TransactionInterface;
 use ElasticApmTests\Util\SpanDto;
 use ElasticApmTests\Util\TestCaseBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 use function ElasticApmTests\dummyFuncForTestsWithNamespace;
 
@@ -107,7 +107,7 @@ final class StackTraceTestSharedCode
     private static function getStringFromExpectedData(array $expectedData, string $key): string
     {
         $value = $expectedData[$key];
-        TestCase::assertIsString($value, LoggableToString::convert(['$key' => $key]));
+        Assert::assertIsString($value, LoggableToString::convert(['$key' => $key]));
         return $value;
     }
 
@@ -120,7 +120,7 @@ final class StackTraceTestSharedCode
     private static function getIntFromExpectedData(array $expectedData, string $key): int
     {
         $value = $expectedData[$key];
-        TestCase::assertIsInt($value, LoggableToString::convert(['$key' => $key]));
+        Assert::assertIsInt($value, LoggableToString::convert(['$key' => $key]));
         return $value;
     }
 
@@ -196,14 +196,14 @@ final class StackTraceTestSharedCode
         );
 
         $actualStacktrace = $span->stackTrace;
-        TestCase::assertNotNull($actualStacktrace);
+        Assert::assertNotNull($actualStacktrace);
         for ($i = 0; $i < count($expectedStacktrace); ++$i) {
             $infoMsg = LoggableToString::convert(
                 ['expected' => $expectedStacktrace[$i], 'actual' => $actualStacktrace[$i]]
             );
-            TestCase::assertSame($expectedStacktrace[$i]->function, $actualStacktrace[$i]->function, $infoMsg);
-            TestCase::assertSame($expectedStacktrace[$i]->filename, $actualStacktrace[$i]->filename, $infoMsg);
-            TestCase::assertSame($expectedStacktrace[$i]->lineno, $actualStacktrace[$i]->lineno, $infoMsg);
+            Assert::assertSame($expectedStacktrace[$i]->function, $actualStacktrace[$i]->function, $infoMsg);
+            Assert::assertSame($expectedStacktrace[$i]->filename, $actualStacktrace[$i]->filename, $infoMsg);
+            Assert::assertSame($expectedStacktrace[$i]->lineno, $actualStacktrace[$i]->lineno, $infoMsg);
         }
     }
 
@@ -217,13 +217,13 @@ final class StackTraceTestSharedCode
         $checkedSpansCount = 0;
         foreach ($idToSpan as $span) {
             $labels = $span->context === null ? [] : $span->context->labels;
-            TestCase::assertNotNull($labels);
+            Assert::assertNotNull($labels);
             if (array_key_exists(self::SPAN_CREATING_API_LABEL_KEY, $labels)) {
                 self::assertPartImplOneSpan($expectedData, $span);
                 ++$checkedSpansCount;
             }
         }
-        TestCase::assertSame($expectedSpansToCheckCount, $checkedSpansCount);
+        Assert::assertSame($expectedSpansToCheckCount, $checkedSpansCount);
     }
 
     public static function buildMethodName(string $fullClassName, string $funcName): string

--- a/tests/ElasticApmTests/TestsSharedCode/TransactionMaxSpansTest/AppCode.php
+++ b/tests/ElasticApmTests/TestsSharedCode/TransactionMaxSpansTest/AppCode.php
@@ -32,7 +32,7 @@ use Elastic\Apm\Impl\Log\LoggableTrait;
 use Elastic\Apm\Impl\NoopSpan;
 use Elastic\Apm\SpanInterface;
 use Elastic\Apm\TransactionInterface;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class AppCode implements LoggableInterface
 {
@@ -72,9 +72,9 @@ final class AppCode implements LoggableInterface
 
     public static function run(Args $testArgs, TransactionInterface $tx): void
     {
-        TestCase::assertGreaterThanOrEqual(0, $testArgs->numberOfSpansToCreate);
-        TestCase::assertGreaterThan(0, $testArgs->maxFanOut);
-        TestCase::assertGreaterThan(0, $testArgs->maxDepth);
+        Assert::assertGreaterThanOrEqual(0, $testArgs->numberOfSpansToCreate);
+        Assert::assertGreaterThan(0, $testArgs->maxFanOut);
+        Assert::assertGreaterThan(0, $testArgs->maxDepth);
         (new self($testArgs, $tx))->runLoop();
     }
 
@@ -83,11 +83,11 @@ final class AppCode implements LoggableInterface
         $depthOnEntry = $this->actualSpansDepth();
         $isTraversingDown = true;
         while (true) {
-            TestCase::assertLessThanOrEqual($this->testArgs->numberOfSpansToCreate, $this->numberOfSpansCreated);
-            TestCase::assertLessThanOrEqual($this->testArgs->maxDepth, $this->actualSpansDepth());
-            TestCase::assertGreaterThanOrEqual($depthOnEntry, $this->actualSpansDepth());
+            Assert::assertLessThanOrEqual($this->testArgs->numberOfSpansToCreate, $this->numberOfSpansCreated);
+            Assert::assertLessThanOrEqual($this->testArgs->maxDepth, $this->actualSpansDepth());
+            Assert::assertGreaterThanOrEqual($depthOnEntry, $this->actualSpansDepth());
             if ($this->actualSpansDepth() > 0) {
-                TestCase::assertLessThanOrEqual($this->testArgs->maxFanOut, $this->topSpanInfo()->childCount);
+                Assert::assertLessThanOrEqual($this->testArgs->maxFanOut, $this->topSpanInfo()->childCount);
             }
 
             if ($isTraversingDown) {
@@ -122,13 +122,13 @@ final class AppCode implements LoggableInterface
     {
         // actualSpansDepth is spanInfoStack->count() - 1 because the bottom entry in spanInfoStack
         // represents the transaction itself
-        TestCase::assertGreaterThanOrEqual(1, $this->spanInfoStack->count());
+        Assert::assertGreaterThanOrEqual(1, $this->spanInfoStack->count());
         return $this->spanInfoStack->count() - 1;
     }
 
     private function topSpanInfo(): SpanInfo
     {
-        TestCase::assertFalse($this->spanInfoStack->isEmpty());
+        Assert::assertFalse($this->spanInfoStack->isEmpty());
         return $this->spanInfoStack->peek();
     }
 
@@ -178,7 +178,7 @@ final class AppCode implements LoggableInterface
         }
 
         if ($this->testArgs->shouldUseOnlyCurrentCreateSpanApis) {
-            TestCase::assertTrue($isTxCurrentSpanTopSpanInfo);
+            Assert::assertTrue($isTxCurrentSpanTopSpanInfo);
         } else {
             $createSpanApis += [self::BEGIN_CHILD_SPAN_API_ID];
             $this->addRecursionApi(self::CAPTURE_CHILD_SPAN_API_ID, /* ref */ $createSpanApis);
@@ -205,7 +205,7 @@ final class AppCode implements LoggableInterface
                 break;
 
             default:
-                TestCase::fail('This point should never be reached. ' . LoggableToString::convert(['this' => $this]));
+                Assert::fail('This point should never be reached. ' . LoggableToString::convert(['this' => $this]));
         }
     }
 }

--- a/tests/ElasticApmTests/TestsSharedCode/TransactionMaxSpansTest/SharedCode.php
+++ b/tests/ElasticApmTests/TestsSharedCode/TransactionMaxSpansTest/SharedCode.php
@@ -31,7 +31,7 @@ use Elastic\Apm\TransactionInterface;
 use ElasticApmTests\Util\DataFromAgent;
 use ElasticApmTests\Util\IterableUtilForTests;
 use ElasticApmTests\Util\TestCaseBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SharedCode
 {
@@ -233,7 +233,7 @@ final class SharedCode
     public static function assertResults(Args $testArgs, DataFromAgent $dataFromAgent): void
     {
         $tx = $dataFromAgent->singleTransaction();
-        TestCase::assertSame($testArgs->isSampled, $tx->isSampled);
+        Assert::assertSame($testArgs->isSampled, $tx->isSampled);
 
         $transactionMaxSpans = $testArgs->configTransactionMaxSpans ?? OptionDefaultValues::TRANSACTION_MAX_SPANS;
         if ($transactionMaxSpans < 0) {
@@ -242,17 +242,17 @@ final class SharedCode
 
         $msg = LoggableToString::convert(['testArgs' => $testArgs, 'dataFromAgent' => $dataFromAgent]);
         if (!$tx->isSampled) {
-            TestCase::assertSame(0, $tx->startedSpansCount, $msg);
-            TestCase::assertSame(0, $tx->droppedSpansCount, $msg);
-            TestCase::assertEmpty($dataFromAgent->idToSpan, $msg);
+            Assert::assertSame(0, $tx->startedSpansCount, $msg);
+            Assert::assertSame(0, $tx->droppedSpansCount, $msg);
+            Assert::assertEmpty($dataFromAgent->idToSpan, $msg);
             return;
         }
 
         $expectedStartedSpansCount = min($testArgs->numberOfSpansToCreate, $transactionMaxSpans);
-        TestCase::assertSame($expectedStartedSpansCount, $tx->startedSpansCount, $msg);
+        Assert::assertSame($expectedStartedSpansCount, $tx->startedSpansCount, $msg);
         $expectedDroppedSpansCount = $testArgs->numberOfSpansToCreate - $expectedStartedSpansCount;
-        TestCase::assertSame($expectedDroppedSpansCount, $tx->droppedSpansCount, $msg);
-        TestCase::assertCount($expectedStartedSpansCount, $dataFromAgent->idToSpan, $msg);
+        Assert::assertSame($expectedDroppedSpansCount, $tx->droppedSpansCount, $msg);
+        Assert::assertCount($expectedStartedSpansCount, $dataFromAgent->idToSpan, $msg);
 
         foreach ($dataFromAgent->idToSpan as $span) {
             $msg2 = $msg . ' spanId: ' . $span->id . '.';
@@ -260,9 +260,9 @@ final class SharedCode
             $createdChildCount = TestCaseBase::getLabel($span, AppCode::NUMBER_OF_CHILD_SPANS_LABEL_KEY);
             $sentChildCount = IterableUtilForTests::count($dataFromAgent->findChildSpans($span->id));
             if ($tx->droppedSpansCount === 0) {
-                TestCase::assertSame($createdChildCount, $sentChildCount, $msg2);
+                Assert::assertSame($createdChildCount, $sentChildCount, $msg2);
             } else {
-                TestCase::assertLessThanOrEqual($createdChildCount, $sentChildCount, $msg2);
+                Assert::assertLessThanOrEqual($createdChildCount, $sentChildCount, $msg2);
             }
         }
     }

--- a/tests/ElasticApmTests/UnitTests/HttpDistributedTracingTest.php
+++ b/tests/ElasticApmTests/UnitTests/HttpDistributedTracingTest.php
@@ -33,7 +33,7 @@ use Elastic\Apm\Impl\Util\RangeUtil;
 use ElasticApmTests\ExternalTestData;
 use ElasticApmTests\UnitTests\Util\TracerUnitTestCaseBase;
 use ElasticApmTests\Util\CharSetForTests;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class HttpDistributedTracingTest extends TracerUnitTestCaseBase
 {
@@ -66,7 +66,7 @@ class HttpDistributedTracingTest extends TracerUnitTestCaseBase
 
     private static function generateVendorKeyEx(int $length, CharSetForTests $firstCharSet): string
     {
-        TestCase::assertGreaterThanOrEqual(0, $length);
+        Assert::assertGreaterThanOrEqual(0, $length);
         if ($length === 0) {
             return '';
         }
@@ -390,7 +390,7 @@ class HttpDistributedTracingTest extends TracerUnitTestCaseBase
     /** @noinspection PhpUnusedPrivateMethodInspection */
     private static function generateOtherVendorKeyValuePairs(int $firstIndex, int $latIndex): string
     {
-        TestCase::assertGreaterThanOrEqual($firstIndex, $latIndex);
+        Assert::assertGreaterThanOrEqual($firstIndex, $latIndex);
         $result = '';
         foreach (RangeUtil::generateFromToIncluding($firstIndex, $latIndex) as $i) {
             if ($i !== $firstIndex) {

--- a/tests/ElasticApmTests/UnitTests/LogTests/LoggingVariousTypesTest.php
+++ b/tests/ElasticApmTests/UnitTests/LogTests/LoggingVariousTypesTest.php
@@ -34,7 +34,7 @@ use Elastic\Apm\Impl\NoopTransaction;
 use Elastic\Apm\Impl\Util\JsonUtil;
 use ElasticApmTests\Util\FloatLimits;
 use ElasticApmTests\Util\TestCaseBase;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class LoggingVariousTypesTest extends TestCaseBase
 {
@@ -60,9 +60,9 @@ class LoggingVariousTypesTest extends TestCaseBase
         }
 
         if (is_array($expectedValue)) {
-            TestCase::assertEquals($expectedValue, $actualValue);
+            Assert::assertEquals($expectedValue, $actualValue);
         } else {
-            TestCase::assertSame($expectedValue, $actualValue);
+            Assert::assertSame($expectedValue, $actualValue);
         }
     }
 

--- a/tests/ElasticApmTests/UnitTests/Util/MockEventSink.php
+++ b/tests/ElasticApmTests/UnitTests/Util/MockEventSink.php
@@ -39,7 +39,7 @@ use ElasticApmTests\Util\MetadataValidator;
 use ElasticApmTests\Util\MetricSetValidator;
 use ElasticApmTests\Util\SpanDto;
 use ElasticApmTests\Util\TransactionDto;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class MockEventSink implements EventSinkInterface
 {
@@ -93,10 +93,10 @@ final class MockEventSink implements EventSinkInterface
     {
         MetadataValidator::assertValid($metadata);
 
-        TestCase::assertNotNull($metadata->process);
-        TestCase::assertSame(getmypid(), $metadata->process->pid);
-        TestCase::assertNotNull($metadata->service->language);
-        TestCase::assertSame(PHP_VERSION, $metadata->service->language->version);
+        Assert::assertNotNull($metadata->process);
+        Assert::assertSame(getmypid(), $metadata->process->pid);
+        Assert::assertNotNull($metadata->service->language);
+        Assert::assertSame(PHP_VERSION, $metadata->service->language->version);
     }
 
     private function consumeMetadata(Metadata $original): void
@@ -108,12 +108,12 @@ final class MockEventSink implements EventSinkInterface
         $deserialized = $this->validateAndDeserializeMetadata($serialized);
 
         self::assertValidMetadata($deserialized);
-        TestCase::assertEquals($original, $deserialized);
+        Assert::assertEquals($original, $deserialized);
     }
 
     private function consumeTransaction(Transaction $original): void
     {
-        TestCase::assertTrue($original->hasEnded());
+        Assert::assertTrue($original->hasEnded());
 
         $serialized = SerializationUtil::serializeAsJson($original);
 
@@ -121,14 +121,14 @@ final class MockEventSink implements EventSinkInterface
         $deserialized->assertValid();
         $deserialized->assertEquals($original);
 
-        TestCase::assertNull($this->dataFromAgent->executionSegmentByIdOrNull($deserialized->id));
+        Assert::assertNull($this->dataFromAgent->executionSegmentByIdOrNull($deserialized->id));
         ArrayUtilForTests::addUnique($deserialized->id, $deserialized, /* ref */ $this->dataFromAgent->idToTransaction);
     }
 
     private function consumeSpan(SpanToSendInterface $original): void
     {
         if ($original instanceof Span) {
-            TestCase::assertTrue($original->hasEnded());
+            Assert::assertTrue($original->hasEnded());
         }
         $serialized = SerializationUtil::serializeAsJson($original);
 
@@ -136,7 +136,7 @@ final class MockEventSink implements EventSinkInterface
         $deserialized->assertValid();
         $deserialized->assertEquals($original);
 
-        TestCase::assertNull($this->dataFromAgent->executionSegmentByIdOrNull($deserialized->id));
+        Assert::assertNull($this->dataFromAgent->executionSegmentByIdOrNull($deserialized->id));
         ArrayUtilForTests::addUnique($deserialized->id, $deserialized, /* ref */ $this->dataFromAgent->idToSpan);
     }
 
@@ -159,7 +159,7 @@ final class MockEventSink implements EventSinkInterface
 
         $deserialized = $this->validateAndDeserializeMetricSet($serialized);
         MetricSetValidator::assertValid($deserialized);
-        TestCase::assertEquals($original, $deserialized);
+        Assert::assertEquals($original, $deserialized);
 
         $this->dataFromAgent->metricSets[] = $deserialized;
     }

--- a/tests/ElasticApmTests/Util/ArrayUtilForTests.php
+++ b/tests/ElasticApmTests/Util/ArrayUtilForTests.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class ArrayUtilForTests
 {
@@ -48,7 +48,7 @@ final class ArrayUtilForTests
      */
     public static function getSingleValue(array $array)
     {
-        TestCase::assertCount(1, $array);
+        Assert::assertCount(1, $array);
         return self::getFirstValue($array);
     }
 
@@ -69,7 +69,7 @@ final class ArrayUtilForTests
      */
     public static function addUnique($key, $value, array &$result): void
     {
-        TestCase::assertArrayNotHasKey(
+        Assert::assertArrayNotHasKey(
             $key,
             $result,
             LoggableToString::convert(['key' => $key, 'value' => $value, 'result' => $result])

--- a/tests/ElasticApmTests/Util/AssertValidTrait.php
+++ b/tests/ElasticApmTests/Util/AssertValidTrait.php
@@ -29,7 +29,7 @@ use Elastic\Apm\Impl\StackTraceFrame;
 use Elastic\Apm\Impl\Util\DbgUtil;
 use Elastic\Apm\Impl\Util\IdValidationUtil;
 use Elastic\Apm\Impl\Util\TextUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 trait AssertValidTrait
 {
@@ -41,9 +41,9 @@ trait AssertValidTrait
      */
     protected static function assertValidIdEx($id, int $expectedSizeInBytes): string
     {
-        TestCase::assertIsString($id);
+        Assert::assertIsString($id);
         /** @var string $id */
-        TestCase::assertTrue(
+        Assert::assertTrue(
             IdValidationUtil::isValidHexNumberString($id, $expectedSizeInBytes),
             LoggableToString::convert(['$id' => $id, '$expectedSizeInBytes' => $expectedSizeInBytes])
         );
@@ -60,15 +60,15 @@ trait AssertValidTrait
     public static function assertValidString($stringValue, bool $isNullable, ?int $maxLength = null): ?string
     {
         if ($stringValue === null) {
-            TestCase::assertTrue($isNullable);
+            Assert::assertTrue($isNullable);
             return null;
         }
 
-        TestCase::assertIsString($stringValue);
+        Assert::assertIsString($stringValue);
         /** @var string $stringValue */
 
         if ($maxLength !== null) {
-            TestCase::assertLessThanOrEqual($maxLength, strlen($stringValue));
+            Assert::assertLessThanOrEqual($maxLength, strlen($stringValue));
         }
         return $stringValue;
     }
@@ -161,7 +161,7 @@ trait AssertValidTrait
         TestCaseBase::assertIsNumber($duration);
         /** @var float|int $duration */
 
-        TestCase::assertGreaterThanOrEqual(0, $duration);
+        Assert::assertGreaterThanOrEqual(0, $duration);
         return floatval($duration);
     }
 
@@ -172,9 +172,9 @@ trait AssertValidTrait
      */
     public static function assertValidStacktraceFrameFilename($filename): string
     {
-        TestCase::assertIsString($filename);
+        Assert::assertIsString($filename);
         /** @var string $filename */
-        TestCase::assertTrue(!TextUtil::isEmptyString($filename));
+        Assert::assertTrue(!TextUtil::isEmptyString($filename));
 
         return $filename;
     }
@@ -186,9 +186,9 @@ trait AssertValidTrait
      */
     public static function assertValidStacktraceFrameLineNumber($lineNumber): int
     {
-        TestCase::assertTrue(is_int($lineNumber));
+        Assert::assertTrue(is_int($lineNumber));
         /** @var int $lineNumber */
-        TestCase::assertTrue($lineNumber >= 0);
+        Assert::assertTrue($lineNumber >= 0);
 
         return $lineNumber;
     }
@@ -201,9 +201,9 @@ trait AssertValidTrait
     public static function assertValidStacktraceFrameFunction($function): ?string
     {
         if ($function !== null) {
-            TestCase::assertIsString($function);
+            Assert::assertIsString($function);
             /** @var string $function */
-            TestCase::assertTrue(!TextUtil::isEmptyString($function));
+            Assert::assertTrue(!TextUtil::isEmptyString($function));
         }
 
         return $function;
@@ -237,7 +237,7 @@ trait AssertValidTrait
             return null;
         }
 
-        TestCase::assertTrue(is_int($value));
+        Assert::assertTrue(is_int($value));
         assert(is_int($value));
         return $value;
     }
@@ -249,7 +249,7 @@ trait AssertValidTrait
      */
     public static function assertValidBool($value): bool
     {
-        TestCase::assertIsBool($value);
+        Assert::assertIsBool($value);
         /** @var bool $value */
         return $value;
     }
@@ -270,7 +270,7 @@ trait AssertValidTrait
     public static function assertEqualOriginalAndDto($original, $dto, string $dbgPath = ''): void
     {
         if (is_object($dto)) {
-            TestCase::assertIsObject($original);
+            Assert::assertIsObject($original);
             $originalPropNameToVal = get_object_vars($original);
             foreach (get_object_vars($dto) as $dtoPropName => $dtoPropVal) {
                 $ctx = LoggableToString::convert(
@@ -285,7 +285,7 @@ trait AssertValidTrait
                     ]
                 );
                 if ($dtoPropVal !== null) {
-                    TestCase::assertArrayHasKey($dtoPropName, $originalPropNameToVal, $ctx);
+                    Assert::assertArrayHasKey($dtoPropName, $originalPropNameToVal, $ctx);
                 }
                 if (array_key_exists($dtoPropName, $originalPropNameToVal)) {
                     self::assertEqualOriginalAndDto(
@@ -299,10 +299,10 @@ trait AssertValidTrait
         }
 
         if (is_array($dto)) {
-            TestCase::assertIsArray($original);
-            TestCase::assertSame(count($original), count($dto));
+            Assert::assertIsArray($original);
+            Assert::assertSame(count($original), count($dto));
             foreach ($dto as $dtoArrayKey => $dtoArrayVal) {
-                TestCase::assertArrayHasKey($dtoArrayKey, $original);
+                Assert::assertArrayHasKey($dtoArrayKey, $original);
                 self::assertEqualOriginalAndDto(
                     $original[$dtoArrayKey],
                     $dtoArrayVal,
@@ -312,6 +312,6 @@ trait AssertValidTrait
             return;
         }
 
-        TestCase::assertSame($original, $dto);
+        Assert::assertSame($original, $dto);
     }
 }

--- a/tests/ElasticApmTests/Util/CharSetForTests.php
+++ b/tests/ElasticApmTests/Util/CharSetForTests.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\Util;
 use Ds\Set;
 use Elastic\Apm\Impl\Util\RangeUtil;
 use IteratorAggregate;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Traversable;
 
 /**
@@ -81,17 +81,17 @@ final class CharSetForTests implements IteratorAggregate
 
     public function addChar(string $char): void
     {
-        TestCase::assertSame(1, strlen($char), $char);
+        Assert::assertSame(1, strlen($char), $char);
         $this->chars->add($char);
     }
 
     public function addCharRange(string $first, string $last): void
     {
-        TestCase::assertSame(1, strlen($first), $first);
-        TestCase::assertSame(1, strlen($last), $last);
+        Assert::assertSame(1, strlen($first), $first);
+        Assert::assertSame(1, strlen($last), $last);
         $firstCodePoint = ord($first);
         $lastCodePoint = ord($last);
-        TestCase::assertGreaterThanOrEqual($firstCodePoint, $lastCodePoint);
+        Assert::assertGreaterThanOrEqual($firstCodePoint, $lastCodePoint);
         foreach (RangeUtil::generateFromToIncluding($firstCodePoint, $lastCodePoint) as $codepoint) {
             $this->addChar(chr($codepoint));
         }
@@ -114,14 +114,14 @@ final class CharSetForTests implements IteratorAggregate
 
     public function getRandom(): string
     {
-        TestCase::assertGreaterThan(0, $this->chars->count());
+        Assert::assertGreaterThan(0, $this->chars->count());
         $randomIndex = mt_rand(0, $this->chars->count() - 1);
         return $this->chars->get($randomIndex);
     }
 
     public function generateString(int $length): string
     {
-        TestCase::assertGreaterThanOrEqual(0, $length);
+        Assert::assertGreaterThanOrEqual(0, $length);
         $result = '';
         while (true) {
             foreach ($this as $char) {

--- a/tests/ElasticApmTests/Util/DataFromAgent.php
+++ b/tests/ElasticApmTests/Util/DataFromAgent.php
@@ -30,7 +30,7 @@ use Elastic\Apm\Impl\Metadata;
 use Elastic\Apm\Impl\MetricSet;
 use Elastic\Apm\Impl\Util\ArrayUtil;
 use ElasticApmTests\ComponentTests\Util\ApmDataKind;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class DataFromAgent implements LoggableInterface
 {
@@ -60,7 +60,7 @@ class DataFromAgent implements LoggableInterface
      */
     private static function singleEvent(array $events)
     {
-        TestCase::assertCount(1, $events);
+        Assert::assertCount(1, $events);
         return ArrayUtilForTests::getFirstValue($events);
     }
 
@@ -109,7 +109,7 @@ class DataFromAgent implements LoggableInterface
     public function singleSpanByName(string $name): SpanDto
     {
         $spans = $this->findSpansByName($name);
-        TestCase::assertCount(
+        Assert::assertCount(
             1,
             $spans,
             LoggableToString::convert(['name' => $name, 'spans' => $spans, 'this' => $this])
@@ -240,7 +240,7 @@ class DataFromAgent implements LoggableInterface
             case ApmDataKind::transaction():
                 return count($this->idToTransaction);
             default:
-                TestCase::fail('Unknown $apmDataKind: ' . $apmDataKind->asString());
+                Assert::fail('Unknown $apmDataKind: ' . $apmDataKind->asString());
         }
     }
 }

--- a/tests/ElasticApmTests/Util/DataFromAgentValidator.php
+++ b/tests/ElasticApmTests/Util/DataFromAgentValidator.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace ElasticApmTests\Util;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class DataFromAgentValidator
 {
@@ -53,11 +53,11 @@ class DataFromAgentValidator
         }
 
         foreach ($this->actual->metadatas as $metadata) {
-            TestCase::assertNotNull($metadata->service->agent);
+            Assert::assertNotNull($metadata->service->agent);
             $agentEphemeralId = $metadata->service->agent->ephemeralId;
-            TestCase::assertNotNull($agentEphemeralId);
+            Assert::assertNotNull($agentEphemeralId);
             self::assertValidNullableKeywordString($agentEphemeralId);
-            TestCase::assertArrayHasKey($agentEphemeralId, $this->expectations->agentEphemeralIdToMetadata);
+            Assert::assertArrayHasKey($agentEphemeralId, $this->expectations->agentEphemeralIdToMetadata);
             MetadataValidator::assertValid(
                 $metadata,
                 $this->expectations->agentEphemeralIdToMetadata[$agentEphemeralId]
@@ -96,10 +96,10 @@ class DataFromAgentValidator
         $spansByTraceId = self::groupByTraceId($this->actual->idToSpan);
         TestCaseBase::assertListArrayIsSubsetOf(array_keys($spansByTraceId), array_keys($transactionsByTraceId));
         foreach ($transactionsByTraceId as $traceId => $idToTransaction) {
-            TestCase::assertIsArray($idToTransaction);
+            Assert::assertIsArray($idToTransaction);
             /** @var array<string, TransactionDto> $idToTransaction */
             $idToSpan = array_key_exists($traceId, $spansByTraceId) ? $spansByTraceId[$traceId] : [];
-            TestCase::assertIsArray($idToSpan);
+            Assert::assertIsArray($idToSpan);
             /** @var array<string, SpanDto> $idToSpan */
             TraceValidator::validate(new TraceActual($idToTransaction, $idToSpan), $this->expectations->trace);
         }

--- a/tests/ElasticApmTests/Util/DataProviderForTestBuilder.php
+++ b/tests/ElasticApmTests/Util/DataProviderForTestBuilder.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace ElasticApmTests\Util;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class DataProviderForTestBuilder
 {
@@ -38,7 +38,7 @@ final class DataProviderForTestBuilder
 
     private function assertValid(): void
     {
-        TestCase::assertSameSize($this->generators, $this->onlyFirstValueCombinable);
+        Assert::assertSameSize($this->generators, $this->onlyFirstValueCombinable);
     }
 
     /**
@@ -52,7 +52,7 @@ final class DataProviderForTestBuilder
         $this->assertValid();
 
         $this->onlyFirstValueCombinable[] = $onlyFirstValueCombinable;
-        TestCase::assertFalse(IterableUtilForTests::isEmpty($generator([])));
+        Assert::assertFalse(IterableUtilForTests::isEmpty($generator([])));
         $this->generators[] = $generator;
 
         $this->assertValid();
@@ -144,7 +144,7 @@ final class DataProviderForTestBuilder
             function (array $resultSoFar) use ($dimensionKey, $iterable): iterable {
                 $expectedKeyForList = 0;
                 foreach ($iterable as $key => $val) {
-                    TestCase::assertSame($expectedKeyForList, $key);
+                    Assert::assertSame($expectedKeyForList, $key);
                     yield array_merge($resultSoFar, [$dimensionKey => $val]);
                     ++$expectedKeyForList;
                 }
@@ -249,7 +249,7 @@ final class DataProviderForTestBuilder
      */
     private static function getIterableFirstValue(iterable $iterable)
     {
-        TestCase::assertTrue(IterableUtilForTests::getFirstValue($iterable, /* out */ $value));
+        Assert::assertTrue(IterableUtilForTests::getFirstValue($iterable, /* out */ $value));
         return $value;
     }
 
@@ -262,7 +262,7 @@ final class DataProviderForTestBuilder
      */
     private function buildImpl(int $genIndexForAllValues, array $resultSoFar, int $currentGenIndex): iterable
     {
-        TestCase::assertLessThanOrEqual(count($this->generators), $currentGenIndex);
+        Assert::assertLessThanOrEqual(count($this->generators), $currentGenIndex);
         if ($currentGenIndex === count($this->generators)) {
             yield $this->shouldWrapResultIntoArray ? [$resultSoFar] : $resultSoFar;
             return;
@@ -346,7 +346,7 @@ final class DataProviderForTestBuilder
     public function build(): iterable
     {
         $this->assertValid();
-        TestCase::assertNotCount(0, $this->generators);
+        Assert::assertNotCount(0, $this->generators);
 
         for ($genIndexForAllValues = 0; $genIndexForAllValues < count($this->generators); ++$genIndexForAllValues) {
             if ($genIndexForAllValues !== 0 && !$this->onlyFirstValueCombinable[$genIndexForAllValues]) {

--- a/tests/ElasticApmTests/Util/DataProviderForTestBuilderTest.php
+++ b/tests/ElasticApmTests/Util/DataProviderForTestBuilderTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Log\LoggableToString;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class DataProviderForTestBuilderTest extends TestCaseBase
 {
@@ -147,11 +147,11 @@ class DataProviderForTestBuilderTest extends TestCaseBase
         // Unpack $disableInstrumentationsVariants pair in each row
         $cartesianProduct = [];
         foreach ($cartesianProductPacked as $cartesianProductPackedRow) {
-            TestCase::assertIsArray($cartesianProductPackedRow);
-            TestCase::assertCount(2, $cartesianProductPackedRow);
+            Assert::assertIsArray($cartesianProductPackedRow);
+            Assert::assertCount(2, $cartesianProductPackedRow);
             $pair = $cartesianProductPackedRow[0];
-            TestCase::assertIsArray($pair);
-            TestCase::assertCount(2, $pair);
+            Assert::assertIsArray($pair);
+            Assert::assertCount(2, $pair);
             $cartesianProductRow = [];
             $cartesianProductRow[] = $pair[0];
             $cartesianProductRow[] = $pair[1];

--- a/tests/ElasticApmTests/Util/Deserialization/DeserializationUtil.php
+++ b/tests/ElasticApmTests/Util/Deserialization/DeserializationUtil.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\Util\Deserialization;
 use Closure;
 use Elastic\Apm\Impl\Util\ExceptionUtil;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 use Throwable;
 
 final class DeserializationUtil
@@ -68,7 +68,7 @@ final class DeserializationUtil
      */
     public static function assertDecodedJsonMap($value): array
     {
-        TestCase::assertIsArray($value);
+        Assert::assertIsArray($value);
         return $value;
     }
 

--- a/tests/ElasticApmTests/Util/Deserialization/JsonDeserializableTrait.php
+++ b/tests/ElasticApmTests/Util/Deserialization/JsonDeserializableTrait.php
@@ -26,7 +26,7 @@ namespace ElasticApmTests\Util\Deserialization;
 use Elastic\Apm\Impl\BackendComm\SerializationUtil;
 use Elastic\Apm\Impl\Util\ClassNameUtil;
 use Elastic\Apm\Impl\Util\JsonUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 trait JsonDeserializableTrait
 {
@@ -55,8 +55,8 @@ trait JsonDeserializableTrait
     public function deserializeFromDecodedJson(array $decodedJson): void
     {
         foreach ($decodedJson as $jsonKey => $jsonVal) {
-            TestCase::assertIsString($jsonKey);
-            TestCase::assertTrue(property_exists($this, $jsonKey));
+            Assert::assertIsString($jsonKey);
+            Assert::assertTrue(property_exists($this, $jsonKey));
             $this->$jsonKey = $this->deserializePropertyValue($jsonKey, $jsonVal);
         }
     }

--- a/tests/ElasticApmTests/Util/Deserialization/JsonUtilForTests.php
+++ b/tests/ElasticApmTests/Util/Deserialization/JsonUtilForTests.php
@@ -27,8 +27,8 @@ use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Util\DbgUtil;
 use Elastic\Apm\Impl\Util\JsonUtil;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\IsType;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -58,9 +58,9 @@ final class JsonUtilForTests
             ['$dbgPathToValue' => $dbgPathToValue, '$value type' => DbgUtil::getType($value), '$value' => $value]
         );
 
-        TestCase::assertThat(
+        Assert::assertThat(
             $value,
-            TestCase::logicalOr(
+            Assert::logicalOr(
                 new IsType(IsType::TYPE_ARRAY),
                 new IsType(IsType::TYPE_BOOL),
                 new IsType(IsType::TYPE_FLOAT),
@@ -77,7 +77,7 @@ final class JsonUtilForTests
                 self::assertJsonDeserializable($arrVal, $dbgPathToValue . '[' . $arrKey . ']');
             }
         } elseif (is_object($value)) {
-            TestCase::assertInstanceOf(JsonDeserializableInterface::class, $value, $dbgInfoAboutValue);
+            Assert::assertInstanceOf(JsonDeserializableInterface::class, $value, $dbgInfoAboutValue);
         }
     }
 }

--- a/tests/ElasticApmTests/Util/Deserialization/ServerApiSchemaValidator.php
+++ b/tests/ElasticApmTests/Util/Deserialization/ServerApiSchemaValidator.php
@@ -32,7 +32,7 @@ use ElasticApmTests\ExternalTestData;
 use ElasticApmTests\Util\FileUtilForTests;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class ServerApiSchemaValidator
 {
@@ -211,7 +211,7 @@ final class ServerApiSchemaValidator
             JsonUtil::encode($schema, /* prettyPrint: */ true),
             /* flags */ LOCK_EX
         );
-        TestCase::assertNotFalse($numberOfBytesWritten, "Failed to write to temp file `$pathToTempFile'");
+        Assert::assertNotFalse($numberOfBytesWritten, "Failed to write to temp file `$pathToTempFile'");
         return $pathToTempFile;
     }
 
@@ -223,7 +223,7 @@ final class ServerApiSchemaValidator
     private static function loadSchemaAndResolveRefs(string $absolutePath): array
     {
         $fileContents = file_get_contents($absolutePath);
-        TestCase::assertNotFalse($fileContents, "Failed to load schema from `$absolutePath'");
+        Assert::assertNotFalse($fileContents, "Failed to load schema from `$absolutePath'");
         $decodedSchema = JsonUtil::decode($fileContents, /* asAssocArray */ true);
         self::resolveRefs($absolutePath, /* ref */ $decodedSchema);
         return $decodedSchema;
@@ -332,7 +332,7 @@ final class ServerApiSchemaValidator
                 $dstArray = &$decodedSchemaNode[$key];
                 /** @var array<mixed, mixed> $value */
                 foreach ($value as $subKey => $subValue) {
-                    TestCase::assertArrayNotHasKey(
+                    Assert::assertArrayNotHasKey(
                         $key,
                         $dstArray,
                         'Failed to merge because key already exists.'

--- a/tests/ElasticApmTests/Util/Deserialization/StacktraceDeserializer.php
+++ b/tests/ElasticApmTests/Util/Deserialization/StacktraceDeserializer.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util\Deserialization;
 
 use Elastic\Apm\Impl\StackTraceFrame;
 use ElasticApmTests\Util\AssertValidTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class StacktraceDeserializer
 {
@@ -44,11 +44,11 @@ final class StacktraceDeserializer
         /** @var int */
         $nextExpectedIndex = 0;
 
-        TestCase::assertIsArray($deserializedRawData);
+        Assert::assertIsArray($deserializedRawData);
         /** @var array<mixed, mixed> $deserializedRawData */
 
         foreach ($deserializedRawData as $key => $value) {
-            TestCase::assertSame($nextExpectedIndex, $key);
+            Assert::assertSame($nextExpectedIndex, $key);
             /** @var array<string, mixed> $value */
             $frames[] = self::deserializeFrame($value);
             ++$nextExpectedIndex;
@@ -72,7 +72,7 @@ final class StacktraceDeserializer
         /** @var string|null */
         $function = null;
 
-        TestCase::assertIsArray($deserializedRawData);
+        Assert::assertIsArray($deserializedRawData);
         /** @var array<mixed, mixed> $deserializedRawData */
         foreach ($deserializedRawData as $key => $value) {
             switch ($key) {
@@ -92,8 +92,8 @@ final class StacktraceDeserializer
                     throw DeserializationUtil::buildException("Unknown key: span_count->`$key'");
             }
         }
-        TestCase::assertNotNull($filename);
-        TestCase::assertNotSame(-1, $lineNumber);
+        Assert::assertNotNull($filename);
+        Assert::assertNotSame(-1, $lineNumber);
 
         $result = new StackTraceFrame($filename, $lineNumber);
         $result->function = $function;

--- a/tests/ElasticApmTests/Util/ErrorTransactionDto.php
+++ b/tests/ElasticApmTests/Util/ErrorTransactionDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class ErrorTransactionDto
 {
@@ -78,7 +78,7 @@ class ErrorTransactionDto
     public function assertMatches(ErrorTransactionExpectations $expectations): void
     {
         if ($expectations->isSampled !== null) {
-            TestCase::assertSame($expectations->isSampled, $this->isSampled);
+            Assert::assertSame($expectations->isSampled, $this->isSampled);
         }
 
         self::assertValidKeywordString($this->name);
@@ -90,7 +90,7 @@ class ErrorTransactionDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations === null || $expectations->isEmpty());
+            Assert::assertTrue($expectations === null || $expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/ExecutionSegmentContextDto.php
+++ b/tests/ElasticApmTests/Util/ExecutionSegmentContextDto.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Constants;
 use Elastic\Apm\Impl\ExecutionSegmentContext;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 abstract class ExecutionSegmentContextDto
 {
@@ -42,10 +42,10 @@ abstract class ExecutionSegmentContextDto
     protected static function assertValidKeyValueMap($map, bool $shouldBeKeywordString): array
     {
         $maxLength = $shouldBeKeywordString ? Constants::KEYWORD_STRING_MAX_LENGTH : null;
-        TestCase::assertIsArray($map);
+        Assert::assertIsArray($map);
         foreach ($map as $key => $value) {
             self::assertValidString($key, /* isNullable: */ false, $maxLength);
-            TestCase::assertTrue(ExecutionSegmentContext::doesValueHaveSupportedLabelType($value));
+            Assert::assertTrue(ExecutionSegmentContext::doesValueHaveSupportedLabelType($value));
             if (is_string($value)) {
                 self::assertValidString($value, /* isNullable: */ false, $maxLength);
             }

--- a/tests/ElasticApmTests/Util/ExecutionSegmentDto.php
+++ b/tests/ElasticApmTests/Util/ExecutionSegmentDto.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Constants;
 use Elastic\Apm\Impl\ExecutionSegment;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 abstract class ExecutionSegmentDto
 {
@@ -127,9 +127,9 @@ abstract class ExecutionSegmentDto
      */
     public static function assertValidOutcome($outcome): ?string
     {
-        TestCase::assertTrue($outcome === null || is_string($outcome));
+        Assert::assertTrue($outcome === null || is_string($outcome));
         /** @var ?string $outcome */
-        TestCase::assertTrue(ExecutionSegment::isValidOutcome($outcome));
+        Assert::assertTrue(ExecutionSegment::isValidOutcome($outcome));
         return $outcome;
     }
 

--- a/tests/ElasticApmTests/Util/IterableUtilForTests.php
+++ b/tests/ElasticApmTests/Util/IterableUtilForTests.php
@@ -27,7 +27,7 @@ use Elastic\Apm\Impl\Util\ArrayUtil;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 use Generator;
 use Iterator;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -171,7 +171,7 @@ final class IterableUtilForTests
                     $tuple[] = $iterator->current();
                     $iterator->next();
                 } else {
-                    TestCase::assertTrue(ArrayUtil::isEmpty($tuple));
+                    Assert::assertTrue(ArrayUtil::isEmpty($tuple));
                 }
             }
 
@@ -179,7 +179,7 @@ final class IterableUtilForTests
                 return;
             }
 
-            TestCase::assertSame(count($iterables), count($tuple));
+            Assert::assertSame(count($iterables), count($tuple));
             yield $tuple;
         }
     }

--- a/tests/ElasticApmTests/Util/MetadataValidator.php
+++ b/tests/ElasticApmTests/Util/MetadataValidator.php
@@ -31,7 +31,7 @@ use Elastic\Apm\Impl\ProcessData;
 use Elastic\Apm\Impl\ServiceAgentData;
 use Elastic\Apm\Impl\ServiceData;
 use Elastic\Apm\Impl\SystemData;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class MetadataValidator
 {
@@ -68,9 +68,9 @@ final class MetadataValidator
      */
     public static function validateProcessId($pid): int
     {
-        TestCase::assertIsInt($pid);
+        Assert::assertIsInt($pid);
         /** @var int $pid */
-        TestCase::assertGreaterThan(0, $pid);
+        Assert::assertGreaterThan(0, $pid);
 
         return $pid;
     }
@@ -108,13 +108,13 @@ final class MetadataValidator
         self::validateNullableNameVersionData($serviceData->framework);
 
         self::validateNullableNameVersionData($serviceData->language);
-        TestCase::assertNotNull($serviceData->language);
-        TestCase::assertSame(MetadataDiscoverer::LANGUAGE_NAME, $serviceData->language->name);
+        Assert::assertNotNull($serviceData->language);
+        Assert::assertSame(MetadataDiscoverer::LANGUAGE_NAME, $serviceData->language->name);
 
         self::validateNullableNameVersionData($serviceData->runtime);
-        TestCase::assertNotNull($serviceData->runtime);
-        TestCase::assertSame(MetadataDiscoverer::LANGUAGE_NAME, $serviceData->runtime->name);
-        TestCase::assertSame($serviceData->language->version, $serviceData->runtime->version);
+        Assert::assertNotNull($serviceData->runtime);
+        Assert::assertSame(MetadataDiscoverer::LANGUAGE_NAME, $serviceData->runtime->name);
+        Assert::assertSame($serviceData->language->version, $serviceData->runtime->version);
     }
 
     private function validateServiceAgentData(): void
@@ -122,7 +122,7 @@ final class MetadataValidator
         $expected = $this->expectations;
         $actual = $this->actual->service->agent;
         if ($actual === null) {
-            TestCase::assertTrue(
+            Assert::assertTrue(
                 !$expected->agentEphemeralId->isValueSet()
                 || $expected->agentEphemeralId->getValue() === null
             );
@@ -136,8 +136,8 @@ final class MetadataValidator
     public static function validateServiceAgentDataEx(ServiceAgentData $serviceAgentData): void
     {
         self::validateNullableNameVersionData($serviceAgentData);
-        TestCase::assertSame(MetadataDiscoverer::AGENT_NAME, $serviceAgentData->name);
-        TestCase::assertSame(ElasticApm::VERSION, $serviceAgentData->version);
+        Assert::assertSame(MetadataDiscoverer::AGENT_NAME, $serviceAgentData->name);
+        Assert::assertSame(ElasticApm::VERSION, $serviceAgentData->version);
         self::assertValidNullableKeywordString($serviceAgentData->ephemeralId);
     }
 
@@ -147,17 +147,17 @@ final class MetadataValidator
         self::assertValidNullableKeywordString($systemData->configuredHostname);
         self::assertValidNullableKeywordString($systemData->detectedHostname);
         if ($systemData->configuredHostname === null) {
-            TestCase::assertSame($systemData->detectedHostname, $systemData->hostname);
+            Assert::assertSame($systemData->detectedHostname, $systemData->hostname);
         } else {
-            TestCase::assertNull($systemData->detectedHostname);
-            TestCase::assertSame($systemData->configuredHostname, $systemData->hostname);
+            Assert::assertNull($systemData->detectedHostname);
+            Assert::assertSame($systemData->configuredHostname, $systemData->hostname);
         }
     }
 
     private function validateSystemData(): void
     {
         self::validateSystemDataEx($this->actual->system);
-        TestCase::assertSame(
+        Assert::assertSame(
             $this->expectations->configuredHostname->isValueSet(),
             $this->expectations->detectedHostname->isValueSet()
         );
@@ -176,8 +176,8 @@ final class MetadataValidator
         SystemData $systemData
     ): void {
 
-        TestCase::assertSame($expectedConfiguredHostname, $systemData->configuredHostname);
-        TestCase::assertSame($expectedDetectedHostname, $systemData->detectedHostname);
+        Assert::assertSame($expectedConfiguredHostname, $systemData->configuredHostname);
+        Assert::assertSame($expectedDetectedHostname, $systemData->detectedHostname);
     }
 
     public static function deriveExpectedServiceName(?string $configured): string

--- a/tests/ElasticApmTests/Util/MetricSetValidator.php
+++ b/tests/ElasticApmTests/Util/MetricSetValidator.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\MetricSet;
 use Elastic\Apm\Impl\Util\ArrayUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class MetricSetValidator
 {
@@ -55,10 +55,10 @@ final class MetricSetValidator
         TestCaseBase::assertSameNullness($this->actual->transactionName, $this->actual->transactionType);
 
         if ($this->actual->spanSubtype !== null) {
-            TestCase::assertNotNull($this->actual->spanType);
+            Assert::assertNotNull($this->actual->spanType);
         }
         if ($this->actual->spanType !== null) {
-            TestCase::assertNotNull($this->actual->transactionType);
+            Assert::assertNotNull($this->actual->transactionType);
         }
 
         self::assertValidSamples($this->actual->samples);
@@ -76,18 +76,18 @@ final class MetricSetValidator
      */
     public static function assertValidSamples($samples): array
     {
-        TestCase::assertTrue(is_array($samples));
+        Assert::assertTrue(is_array($samples));
         /** @var array<mixed, mixed> $samples */
-        TestCase::assertTrue(!ArrayUtil::isEmpty($samples));
+        Assert::assertTrue(!ArrayUtil::isEmpty($samples));
 
         foreach ($samples as $key => $valueArr) {
             self::assertValidKeywordString($key);
-            TestCase::assertTrue(is_array($valueArr));
+            Assert::assertTrue(is_array($valueArr));
             /** @var array<mixed, mixed> $valueArr */
-            TestCase::assertTrue(count($valueArr) === 1);
-            TestCase::assertTrue(array_key_exists('value', $valueArr));
+            Assert::assertTrue(count($valueArr) === 1);
+            Assert::assertTrue(array_key_exists('value', $valueArr));
             $value = $valueArr['value'];
-            TestCase::assertTrue(is_int($value) || is_float($value));
+            Assert::assertTrue(is_int($value) || is_float($value));
             /** @var float|int $value */
         }
         /** @var array<string, array<string, float|int>> $samples */

--- a/tests/ElasticApmTests/Util/Optional.php
+++ b/tests/ElasticApmTests/Util/Optional.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Log\LoggableInterface;
 use Elastic\Apm\Impl\Log\LoggableTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @template T
@@ -45,7 +45,7 @@ final class Optional implements LoggableInterface
      */
     public function getValue()
     {
-        TestCase::assertTrue($this->isValueSet);
+        Assert::assertTrue($this->isValueSet);
         return $this->value;
     }
 

--- a/tests/ElasticApmTests/Util/RandomUtilForTests.php
+++ b/tests/ElasticApmTests/Util/RandomUtilForTests.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Util\StaticClassTrait;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
@@ -107,11 +107,11 @@ final class RandomUtilForTests
         if ($subSetSize === 1) {
             $randSelectedSubsetIndexes = [$randSelectedSubsetIndexes];
         }
-        TestCase::assertIsArray($randSelectedSubsetIndexes);
+        Assert::assertIsArray($randSelectedSubsetIndexes);
 
         $randSelectedSubsetValues = [];
         foreach ($randSelectedSubsetIndexes as $index) {
-            TestCase::assertIsInt($index);
+            Assert::assertIsInt($index);
             $randSelectedSubsetValues[] = $totalSet[$index];
         }
         return $randSelectedSubsetValues;
@@ -126,7 +126,7 @@ final class RandomUtilForTests
      */
     public static function getRandomValueFromArray(array $arr)
     {
-        TestCase::assertGreaterThan(0, count($arr));
+        Assert::assertGreaterThan(0, count($arr));
         return $arr[RandomUtilForTests::generateIntInRange(0, count($arr) - 1)];
     }
 
@@ -140,7 +140,7 @@ final class RandomUtilForTests
      */
     public static function getRandomKeyValueFromArray(array $arr)
     {
-        TestCase::assertGreaterThan(0, count($arr));
+        Assert::assertGreaterThan(0, count($arr));
         $selectedIndex = RandomUtilForTests::generateIntInRange(0, count($arr) - 1);
         return array_slice($arr, /* offset: */ $selectedIndex, /* length: */ 1, /* preserve_keys: */ true);
     }

--- a/tests/ElasticApmTests/Util/SpanContextDbDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextDbDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextDbDto
 {
@@ -71,7 +71,7 @@ final class SpanContextDbDto
     public static function assertNullableMatches(SpanContextDbExpectations $expectations, ?self $actual): void
     {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextDestinationDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextDestinationDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextDestinationDto
 {
@@ -73,7 +73,7 @@ final class SpanContextDestinationDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextDestinationServiceDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextDestinationServiceDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextDestinationServiceDto
 {
@@ -87,7 +87,7 @@ final class SpanContextDestinationServiceDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextDto extends ExecutionSegmentContextDto
 {
@@ -99,7 +99,7 @@ final class SpanContextDto extends ExecutionSegmentContextDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextHttpDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextHttpDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextHttpDto
 {
@@ -90,7 +90,7 @@ final class SpanContextHttpDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextServiceDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextServiceDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextServiceDto
 {
@@ -73,7 +73,7 @@ final class SpanContextServiceDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanContextServiceTargetDto.php
+++ b/tests/ElasticApmTests/Util/SpanContextServiceTargetDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanContextServiceTargetDto
 {
@@ -80,7 +80,7 @@ final class SpanContextServiceTargetDto
         ?self $actual
     ): void {
         if ($actual === null) {
-            TestCase::assertTrue($expectations->isEmpty());
+            Assert::assertTrue($expectations->isEmpty());
             return;
         }
 

--- a/tests/ElasticApmTests/Util/SpanDto.php
+++ b/tests/ElasticApmTests/Util/SpanDto.php
@@ -30,7 +30,7 @@ use Elastic\Apm\Impl\Util\ClassNameUtil;
 use Elastic\Apm\Impl\Util\RangeUtil;
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
 use ElasticApmTests\Util\Deserialization\StacktraceDeserializer;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class SpanDto extends ExecutionSegmentDto
 {
@@ -110,12 +110,12 @@ class SpanDto extends ExecutionSegmentDto
         self::assertSameNullableKeywordStringExpectedOptional($expectations->action, $this->action);
         self::assertSameNullableKeywordStringExpectedOptional($expectations->subtype, $this->subtype);
         if ($this->stackTrace === null) {
-            TestCase::assertNull($expectations->stackTrace);
-            TestCase::assertNull($expectations->allowExpectedStackTraceToBePrefix);
+            Assert::assertNull($expectations->stackTrace);
+            Assert::assertNull($expectations->allowExpectedStackTraceToBePrefix);
         } else {
             self::assertValidStacktrace($this->stackTrace);
             if ($expectations->stackTrace !== null) {
-                TestCase::assertNotNull($expectations->allowExpectedStackTraceToBePrefix);
+                Assert::assertNotNull($expectations->allowExpectedStackTraceToBePrefix);
                 self::assertStackTraceMatches(
                     $expectations->stackTrace,
                     $expectations->allowExpectedStackTraceToBePrefix,
@@ -151,9 +151,9 @@ class SpanDto extends ExecutionSegmentDto
         );
         $ctxTopStr = LoggableToString::convert($ctxTop);
         if ($allowExpectedStackTraceToBePrefix) {
-            TestCase::assertGreaterThanOrEqual(count($expectedStackTrace), count($actualStackTrace), $ctxTopStr);
+            Assert::assertGreaterThanOrEqual(count($expectedStackTrace), count($actualStackTrace), $ctxTopStr);
         } else {
-            TestCase::assertSame(count($expectedStackTrace), count($actualStackTrace), $ctxTopStr);
+            Assert::assertSame(count($expectedStackTrace), count($actualStackTrace), $ctxTopStr);
         }
         $expectedStackTraceCount = count($expectedStackTrace);
         $actualStackTraceCount = count($actualStackTrace);
@@ -170,7 +170,7 @@ class SpanDto extends ExecutionSegmentDto
                 $ctxTop
             );
             $ctxPerFrameStr = LoggableToString::convert($ctxPerFrame);
-            TestCase::assertSame(count($expectedApmFrame), count($actualApmFrame), $ctxPerFrameStr);
+            Assert::assertSame(count($expectedApmFrame), count($actualApmFrame), $ctxPerFrameStr);
             foreach ($expectedApmFrame as $expectedPropName => $expectedPropVal) {
                 $ctxPerProp = LoggableToString::convert(
                     array_merge(

--- a/tests/ElasticApmTests/Util/SpanExpectationsBuilder.php
+++ b/tests/ElasticApmTests/Util/SpanExpectationsBuilder.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Util\StackTraceUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 /**
  * @extends ExpectationsBuilderBase<SpanExpectations>
@@ -56,7 +56,7 @@ class SpanExpectationsBuilder extends ExpectationsBuilderBase
     ): SpanExpectations {
         $result = $this->startNew();
         $name = StackTraceUtil::convertClassAndMethodToFunctionName($className, $isStatic, $methodName);
-        TestCase::assertNotNull($name);
+        Assert::assertNotNull($name);
         $result->name->setValue($name);
         return $result;
     }

--- a/tests/ElasticApmTests/Util/SpanSequenceValidator.php
+++ b/tests/ElasticApmTests/Util/SpanSequenceValidator.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Log\LoggableToString;
 use Elastic\Apm\Impl\Util\StaticClassTrait;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class SpanSequenceValidator
 {
@@ -69,7 +69,7 @@ final class SpanSequenceValidator
     public static function assertSequenceAsExpected(array $expected, array $actual): void
     {
         $dbgCtx = LoggableToString::convert(['$expected' => $expected, '$actual' => $actual,]);
-        TestCase::assertSame(count($expected), count($actual), $dbgCtx);
+        Assert::assertSame(count($expected), count($actual), $dbgCtx);
 
         $actualSortedByStartTime = self::sortByStartTime($actual);
         for ($i = 0; $i < count($actual); ++$i) {

--- a/tests/ElasticApmTests/Util/TestCaseBase.php
+++ b/tests/ElasticApmTests/Util/TestCaseBase.php
@@ -43,6 +43,7 @@ use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\LessThan;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -261,7 +262,7 @@ class TestCaseBase extends TestCase
      */
     public static function assertArrayIsList(array $actual): void
     {
-        TestCase::assertTrue(ArrayUtil::isList($actual), LoggableToString::convert(['$actual' => $actual]));
+        Assert::assertTrue(ArrayUtil::isList($actual), LoggableToString::convert(['$actual' => $actual]));
     }
 
     /**
@@ -446,7 +447,7 @@ class TestCaseBase extends TestCase
      */
     public static function assertSameNullness($expected, $actual, string $message = ''): void
     {
-        TestCase::assertThat(
+        Assert::assertThat(
             $actual,
             ($expected === null) ? TestCase::isNull() : TestCase::logicalNot(TestCase::isNull()),
             LoggableToString::convert(
@@ -467,7 +468,7 @@ class TestCaseBase extends TestCase
      */
     public static function assertIsNumber($actual, string $message = ''): void
     {
-        TestCase::assertThat(
+        Assert::assertThat(
             $actual,
             TestCase::logicalOr(new IsType(IsType::TYPE_INT), new IsType(IsType::TYPE_FLOAT)),
             $message
@@ -476,7 +477,7 @@ class TestCaseBase extends TestCase
 
     public static function assertGreaterThanZero(int $actual, string $message = ''): void
     {
-        TestCase::assertGreaterThan(0, $actual, $message);
+        Assert::assertGreaterThan(0, $actual, $message);
     }
 
     /**
@@ -487,7 +488,7 @@ class TestCaseBase extends TestCase
      */
     public static function assertInClosedRange($rangeBegin, $actual, $rangeEnd, string $message = ''): void
     {
-        TestCase::assertThat(
+        Assert::assertThat(
             $actual,
             TestCase::logicalAnd(
                 TestCase::logicalOr(new IsEqual($rangeBegin), new GreaterThan($rangeBegin)),
@@ -499,7 +500,7 @@ class TestCaseBase extends TestCase
 
     public static function assertLessThanOrEqualTimestamp(float $before, float $after): void
     {
-        TestCase::assertThat(
+        Assert::assertThat(
             $before,
             TestCase::logicalOr(
                 new IsEqual($after, /* delta: */ self::TIMESTAMP_COMPARISON_PRECISION_MICROSECONDS),

--- a/tests/ElasticApmTests/Util/TransactionContextRequestDto.php
+++ b/tests/ElasticApmTests/Util/TransactionContextRequestDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class TransactionContextRequestDto
 {
@@ -66,10 +66,10 @@ final class TransactionContextRequestDto
 
     public function assertValid(): void
     {
-        TestCase::assertNotNull($this->method);
+        Assert::assertNotNull($this->method);
         self::assertValidKeywordString($this->method);
 
-        TestCase::assertNotNull($this->url);
+        Assert::assertNotNull($this->url);
         $this->url->assertValid();
     }
 }

--- a/tests/ElasticApmTests/Util/TransactionContextRequestUrlDto.php
+++ b/tests/ElasticApmTests/Util/TransactionContextRequestUrlDto.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace ElasticApmTests\Util;
 
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 final class TransactionContextRequestUrlDto
 {
@@ -105,7 +105,7 @@ final class TransactionContextRequestUrlDto
             return null;
         }
 
-        TestCase::assertIsInt($value);
+        Assert::assertIsInt($value);
         /** @var int $value */
         return $value;
     }

--- a/tests/ElasticApmTests/Util/TransactionDto.php
+++ b/tests/ElasticApmTests/Util/TransactionDto.php
@@ -25,7 +25,7 @@ namespace ElasticApmTests\Util;
 
 use Elastic\Apm\Impl\Transaction;
 use ElasticApmTests\Util\Deserialization\DeserializationUtil;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class TransactionDto extends ExecutionSegmentDto
 {
@@ -124,20 +124,20 @@ class TransactionDto extends ExecutionSegmentDto
         }
 
         if ($expectations->isSampled !== null) {
-            TestCase::assertSame($expectations->isSampled, $this->isSampled);
+            Assert::assertSame($expectations->isSampled, $this->isSampled);
         }
 
         self::assertValidCount($this->startedSpansCount);
         self::assertValidCount($this->droppedSpansCount);
 
         if (!$this->isSampled) {
-            TestCase::assertSame(0, $this->startedSpansCount);
-            TestCase::assertSame(0, $this->droppedSpansCount);
-            TestCase::assertNull($this->context);
+            Assert::assertSame(0, $this->startedSpansCount);
+            Assert::assertSame(0, $this->droppedSpansCount);
+            Assert::assertNull($this->context);
         }
 
         if ($expectations->droppedSpansCount !== null) {
-            TestCase::assertSame($expectations->droppedSpansCount, $this->droppedSpansCount);
+            Assert::assertSame($expectations->droppedSpansCount, $this->droppedSpansCount);
         }
 
         if ($this->context !== null) {
@@ -152,9 +152,9 @@ class TransactionDto extends ExecutionSegmentDto
      */
     public static function assertValidCount($count): int
     {
-        TestCase::assertIsInt($count);
+        Assert::assertIsInt($count);
         /** @var int $count */
-        TestCase::assertGreaterThanOrEqual(0, $count);
+        Assert::assertGreaterThanOrEqual(0, $count);
         return $count;
     }
 

--- a/tests/ElasticApmTests/dummyFuncForTestsWithNamespace.php
+++ b/tests/ElasticApmTests/dummyFuncForTestsWithNamespace.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace ElasticApmTests;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 const DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_NAMESPACE = __NAMESPACE__;
 const DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_FILE_NAME = __FILE__;
@@ -36,6 +36,6 @@ const DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_LINE_NUMBER = 40;
  */
 function dummyFuncForTestsWithNamespace(callable $callable): void
 {
-    TestCase::assertSame(DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_LINE_NUMBER, __LINE__ + 1);
     $callable(); // DUMMY_FUNC_FOR_TESTS_WITH_NAMESPACE_CALLABLE_LINE_NUMBER should be this line number
 }

--- a/tests/dummyFuncForTestsWithoutNamespace.php
+++ b/tests/dummyFuncForTestsWithoutNamespace.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 const DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_FILE_NAME = __FILE__;
 const DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_LINE_NUMBER = 37;
@@ -33,6 +33,6 @@ const DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_LINE_NUMBER = 37;
  */
 function dummyFuncForTestsWithoutNamespace(callable $callable): void
 {
-    TestCase::assertSame(DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_LINE_NUMBER, __LINE__ + 1);
+    Assert::assertSame(DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_LINE_NUMBER, __LINE__ + 1);
     $callable(); // DUMMY_FUNC_FOR_TESTS_WITHOUT_NAMESPACE_CALLABLE_LINE_NUMBER should be this line number
 }


### PR DESCRIPTION
Reads a bit more cleanly and it’s what PHPUnit advertises in their docs (https://phpunit.readthedocs.io/en/9.5/assertions.html)