### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/APM_Server_intake_API_schema/latest_used/span.json
+++ b/tests/APM_Server_intake_API_schema/latest_used/span.json
@@ -181,6 +181,22 @@
               ],
               "maxLength": 1024
             },
+            "request": {
+              "description": "Request describes the HTTP request information.",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "description": "ID holds the unique identifier for the http request.",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "response": {
               "description": "Response describes the HTTP response information in case the event was created as a result of an HTTP request.",
               "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/8c0634c4e Add `request.id` to `span.context.http` intake (https://github.com/elastic/apm-server/pull/9673)