### PR TITLE
ci: release automation with GH and Buildkite (scaffolding) with manual dry-run

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##  This script prepares the Vault context and required tooling
+##  for the release pipelines.
+##
+##  NOTE: *_SECRET or *_TOKEN env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET or _TOKEN for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+
+set -eo pipefail
+
+echo "--- Prepare vault context :vault:"
+INTERNAL_CI_TOKEN=$(vault read -field=token secret/ci/elastic-apm-agent-php/internal-ci-token)
+export INTERNAL_CI_TOKEN
+INTERNAL_CI_JOB_URL_SECRET=$(vault read -field=job-url secret/ci/elastic-apm-agent-php/internal-ci-token)
+export INTERNAL_CI_JOB_URL_SECRET

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,0 +1,14 @@
+agents:
+  provider: "gcp"
+
+steps:
+  - label: "Run the release"
+    key: "release"
+    commands: .ci/release.sh
+    artifact_paths: "release.txt"
+
+notify:
+  - slack:
+      channels:
+        #- "#apm-agent-php"
+        - "#on-week-oblt-productivity"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+##  This script runs the release given the different environment variables
+##    dry_run
+##
+##  It relies on the .buildkite/hooks/pre-command so the Vault and other tooling
+##  are prepared automatically by buildkite.
+##
+set -eo pipefail
+
+set +x
+echo "--- Release the binaries to Maven Central :maven:"
+if [[ "$dry_run" == "true" ]] ; then
+  echo "run the signing job 'elastic+unified-release+master+sign-artifacts-with-gpg'" | tee -a release.txt
+else
+  echo 'TBD' | tee release.txt
+fi
+

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -8,7 +8,7 @@
 set -eo pipefail
 
 set +x
-echo "--- Release the binaries to Maven Central :maven:"
+echo "--- Sign the binaries"
 if [[ "$dry_run" == "true" ]] ; then
   echo "run the signing job 'elastic+unified-release+master+sign-artifacts-with-gpg'" | tee -a release.txt
 else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+---
+name: release
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  ### TODO: listen for tags, so for now let's test whether it works in dry run mode by default
+  #create:
+  #  tags: [ "v*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+        dockerfile:
+          - "Dockerfile"
+          - "Dockerfile.alpine"
+    env:
+      PHP_VERSION: ${{ matrix.php-version }}
+      DOCKERFILE: ${{ matrix.dockerfile }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: make -f .ci/Makefile build
+      - name: Build parts for packages
+        run: make -f .ci/Makefile generate-for-package
+      - uses: actions/upload-artifact@v3
+        with:
+          name: package-parts
+          path: src/ext/modules/*.so
+  generate-packages:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: package-parts
+          path: src/ext/modules
+      - name: package
+        run: make -C packaging package
+      - name: package info
+        run: make -C packaging info
+      - uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: |
+            build/packages/*
+            !build/packages/**/*.sha512
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: package
+          path: build/packages
+      - run: echo "Upload artifacts to gs://internal-ci-artifacts/apm-agent-php/<TAG>"
+
+      - id: buildkite
+        name: Run Release
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: apm-agent-php-release
+          waitFor: true
+          printBuildLogs: true
+          buildEnvVars: |
+            dry_run=true
+
+      - run: echo "Download artifacts from  gs://internal-ci-artifacts/apm-agent-php/<TAG>/signed-artifacts"
+
+      - run: echo "Run tests"
+
+      - run: echo "here is no approval input"
+
+      - run: echo "Publish draft release"
+
+      - run: echo "Verify draft release checksum"
+
+      - run: echo "Publish release (draft -> regular)"
+
+      - if: ${{ success() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          #channel: "#apm-agent-php"
+          channel: "#on-week-oblt-productivity"
+          message: |
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          #channel: "#apm-agent-php"
+          channel: "#on-week-oblt-productivity"
+          message: |
+            :ghost: [${{ github.repository }}] Release *${{ github.ref_name }}* didn't get triggered in Buildkite.
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)


### PR DESCRIPTION
### What

Migrate release from Jenkins to GItHub actions with Buildkite.

### Why

Jenkins ecosystem will be decommissioned so, we need to use the toolchain provided by the RelEng team, so that's the reason for using Buildkite. The Buildkite pipeline will pretty much sign the artifacts and report back so the GH action can move forward.

For now, we will need to call from the Buildkite pipeline the Jenkins job, that will help us to move things forward, that will be changed once the RelEng team provides the toolchain to be run in Buildkite for signing artifacts. In any case, that particular implementation detail, will not change the GitHub actions.

### Follow ups

- Code the rest of the releases staged
- Create BK pipeline
- Dry-run
- Enable for Git Tags
- Disable `internal-ci` pipeline.

### Questions

- Is the [pre-release step ](https://github.com/elastic/apm-agent-php/blob/78fb2abb6dc8a0ca5df747eef7c891c0b9280ec9/.ci/Jenkinsfile#L66-L86)required? Or can we remove that logic and use git tag events instead?