### PR TITLE
action: report failure if tests were not found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           name: test-results
           path: build/*junit.xml
+          if-no-files-found: error
   build-packages:
     runs-on: ubuntu-latest
     needs:
@@ -174,3 +175,4 @@ jobs:
         with:
           name: test-results
           path: build/*junit.xml
+          if-no-files-found: error


### PR DESCRIPTION
Does what it says in the tin

### Why

It can help to detect misbehaviours when running the make goals and tests are not executed or even reported