### PR TITLE
action: abort builds when new commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     name: static-checks-unit-tests


### PR DESCRIPTION
### What

Abort old running builds when a new commit has been pushed to the existing Pull Request.

### Why

Save cost 


### Further details

See https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow 