### PR TITLE
make: disable Entering/Leaving directory messages

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -1,5 +1,6 @@
 
 SHELL=/bin/bash -o pipefail
+MAKEFLAGS += --no-print-directory
 IMAGE := test-php
 PHP_VERSION ?= 7.2
 DOCKERFILE ?= Dockerfile

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,4 +1,5 @@
 SHELL = /bin/bash
+MAKEFLAGS += --no-print-directory
 IMAGE:=php-packaging
 NAME:=apm-agent-php
 VERSION?=$(shell grep 'VERSION' ../src/ElasticApm/ElasticApm.php | cut -d= -f2 | tr -d " " | sed "s/'\(.*\)'.*/\1/g")


### PR DESCRIPTION
Cosmetic change so no more output like

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/2871786/224266090-161de221-393d-4384-8d9b-a23c2ec12e92.png">

that will make https://github.com/elastic/apm-agent-php/pull/885 much nicer with just groups and logs