### PR TITLE
Enable libunwind stacktrace printing with additional debug information (1014)

### DIFF
--- a/agent/native/ext/platform.c
+++ b/agent/native/ext/platform.c
@@ -36,6 +36,8 @@
 #   include <syslog.h>
 #   include <signal.h>
 #   include <errno.h>
+#define __USE_GNU
+#include <dlfcn.h>
 #endif
 
 #if defined( ELASTIC_APM_PLATFORM_HAS_LIBUNWIND )
@@ -378,30 +380,43 @@ void iterateOverCStackTraceLibUnwind( size_t numberOfFramesToSkip, IterateOverCS
     for (;; ++frameIndex)
     {
         // +1 is for this function frame
-        if ( frameIndex >= numberOfFramesToSkip + 1 )
-        {
-            // https://www.nongnu.org/libunwind/man/unw_get_proc_name(3).html
-            int getProcNameRetVal = unw_get_proc_name( &unwindCursor, funcNameBuffer, funcNameBufferSize, &offsetInsideFunc );
+        if ( frameIndex >= numberOfFramesToSkip + 1 ) {
             textOutputStreamRewind( &txtOutStream );
-            switch ( getProcNameRetVal ) // https://www.nongnu.org/libunwind/man/unw_get_proc_name(3).html
-            {
-                case 0: // On successful completion, unw_get_proc_name() returns 0
-                    callback( streamPrintf( &txtOutStream, "%s + 0x%X", funcNameBuffer, (unsigned int)offsetInsideFunc ), callbackCtx );
-                    break;
-                case UNW_EUNSPEC: // An unspecified error occurred.
-                    logErrorCallback( streamPrintf( &txtOutStream, "unw_get_proc_name call failed with return value UNW_EUNSPEC - stopping iteration over call stack" ), callbackCtx );
-                    return;
-                case UNW_ENOINFO: // Libunwind was unable to determine the name of the procedure.
-                    callback( NULL, callbackCtx );
-                    break;
-                case UNW_ENOMEM: // The procedure name is too long to fit in the buffer provided. A truncated version of the name has been returned.
-                    callback( streamPrintf( &txtOutStream, "%s (truncated) + 0x%X", funcNameBuffer, (unsigned int)offsetInsideFunc ), callbackCtx );
-                    break;
-                default:
-                    logErrorCallback( streamPrintf( &txtOutStream, "unw_get_proc_name call failed with an unexpected return value (%d) - stopping iteration over call stack", getProcNameRetVal ), callbackCtx );
-                    return;
+            unw_proc_info_t pi;
+            if (unw_get_proc_info(&unwindCursor, &pi) == 0) {
+                *funcNameBuffer = 0;
+                offsetInsideFunc = 0;
+                int getProcNameRetVal = unw_get_proc_name( &unwindCursor, funcNameBuffer, funcNameBufferSize, &offsetInsideFunc );
+                if (getProcNameRetVal != UNW_ESUCCESS && getProcNameRetVal != -UNW_ENOMEM) {
+                    strcpy(funcNameBuffer, "???");
+                    unw_word_t  pc;
+                    unw_get_reg(&unwindCursor, UNW_REG_IP, &pc);
+                    offsetInsideFunc = pc - pi.start_ip;
+                }
+
+                Dl_info dlInfo;
+                if (dladdr((const void *)pi.gp, &dlInfo)) {
+                    callback( streamPrintf( &txtOutStream, 
+                        "%s(%s+%lx) modbase: %p fstart: %lx fend: %lx fstartrel: %lx rel: %lx\n\t'addr2line  -afCp -e \"%s\" %lx'\n",
+                        dlInfo.dli_fname ? dlInfo.dli_fname : "???",
+                        dlInfo.dli_sname ? dlInfo.dli_sname : funcNameBuffer,
+                        offsetInsideFunc,
+                        dlInfo.dli_fbase,
+                        pi.start_ip,
+                        pi.end_ip,
+                        (void*)pi.start_ip -  dlInfo.dli_fbase,
+                        (void*)pi.start_ip -  dlInfo.dli_fbase + offsetInsideFunc,
+                        dlInfo.dli_fname ? dlInfo.dli_fname : funcNameBuffer,
+                        (void*)pi.start_ip -  dlInfo.dli_fbase + offsetInsideFunc
+                        ), callbackCtx );
+                } else {
+                    callback( streamPrintf( &txtOutStream, "dladdr failed on frame %zu", frameIndex), callbackCtx );
+                }
+            } else {
+                callback( streamPrintf( &txtOutStream, "unw_get_proc_info failed on frame %zu", frameIndex), callbackCtx );
             }
         }
+       
         int unwindStepRetVal = 0;
         ELASTIC_APM_LIBUNWIND_CALL_RETURN_ON_ERROR( unwindStepRetVal = unw_step( &unwindCursor ) );
         if ( unwindStepRetVal == 0 )

--- a/agent/native/ext/unit_tests/CMakeLists.txt
+++ b/agent/native/ext/unit_tests/CMakeLists.txt
@@ -111,6 +111,8 @@ LIST( APPEND source_files ${src_ext_dir}/time_util.h ${src_ext_dir}/time_util.c 
 LIST( APPEND source_files ${src_ext_dir}/Tracer.h ${src_ext_dir}/Tracer.c )
 LIST( APPEND source_files ${src_ext_dir}/Tracer.h ${src_ext_dir}/util.c )
 
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -pthread -ldl")
+
 IF ( NOT WIN32 )
     ADD_LINK_OPTIONS( -rdynamic )
 ENDIF()


### PR DESCRIPTION
 * it will also print command to fetch function and line from external debug symbols file

Example output:
```
     Call stack frame: /lib/x86_64-linux-gnu/libc.so.6(killpg+40) modbase: 0x7fed9730f000 fstart: 7fed97347d5f fend: 7fed97347d69 fstartrel: 38d5f rel: 38d9f
 	'addr2line  -afCp -e "/lib/x86_64-linux-gnu/libc.so.6" 38d9f'
     Call stack frame: /opt/elastic/ext/elastic_apm-20200930.so(???+5a) modbase: 0x7fed92f47000 fstart: 7fed92f96680 fend: 7fed92f96713 fstartrel: 4f680 rel: 4f6da
 	'addr2line  -afCp -e "/opt/elastic/ext/elastic_apm-20200930.so" 4f6da'
     Call stack frame: /opt/elastic/ext/elastic_apm-20200930.so(???+8c) modbase: 0x7fed92f47000 fstart: 7fed92f84cd0 fend: 7fed92f859e4 fstartrel: 3dcd0 rel: 3dd5c
 	'addr2line  -afCp -e "/opt/elastic/ext/elastic_apm-20200930.so" 3dd5c'
     Call stack frame: /opt/elastic/ext/elastic_apm-20200930.so(???+25) modbase: 0x7fed92f47000 fstart: 7fed92f78800 fend: 7fed92f7882c fstartrel: 31800 rel: 31825
 	'addr2line  -afCp -e "/opt/elastic/ext/elastic_apm-20200930.so" 31825'
     Call stack frame: php-fpm: pool www(zend_activate_modules+30) modbase: 0x55e47b600000 fstart: 55e47bb21dd0 fend: 55e47bb21e1d fstartrel: 521dd0 rel: 521e00
 	'addr2line  -afCp -e "php-fpm: pool www" 521e00'
     Call stack frame: php-fpm: pool www(php_request_startup+184) modbase: 0x55e47b600000 fstart: 55e47bab76f0 fend: 55e47bab7970 fstartrel: 4b76f0 rel: 4b7874
 	'addr2line  -afCp -e "php-fpm: pool www" 4b7874'
     Call stack frame: php-fpm: pool www(zend_std_unset_static_property+24cc) modbase: 0x55e47b600000 fstart: 55e47b841c20 fend: 55e47b8437f3 fstartrel: 241c20 rel: 2440ec
 	'addr2line  -afCp -e "php-fpm: pool www" 2440ec'
     Call stack frame: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+ea) modbase: 0x7fed9730f000 fstart: 7fed97332c20 fend: 7fed97332dfc fstartrel: 23c20 rel: 23d0a
 	'addr2line  -afCp -e "/lib/x86_64-linux-gnu/libc.so.6" 23d0a'
     Call stack frame: php-fpm: pool www(_start+2a) modbase: 0x55e47b600000 fstart: 55e47b843e20 fend: 55e47b843e4b fstartrel: 243e20 rel: 243e4a
 	'addr2line  -afCp -e "php-fpm: pool www" 243e4a'

```

Example output from addr2line 
```
$ addr2line  -afCp -e "elastic_apm-20200930.so" 4f6da
0x000000000004f6da: detectOpcacheRestartPending at /home/paplo/sources/apm-agent-php/agent/native/ext/util_for_PHP.c:307
```
which corresponds to bug I implemented to test it
```

 306:   char *p = NULL;
 307:   *p = 1;
```
