### PR TITLE
Wrap `__USE_GNU` flag with `ifndef`

### DIFF
--- a/agent/native/ext/platform.c
+++ b/agent/native/ext/platform.c
@@ -37,8 +37,10 @@
 #   include <syslog.h>
 #   include <signal.h>
 #   include <errno.h>
-#define __USE_GNU
-#include <dlfcn.h>
+#   ifndef __USE_GNU
+#       define __USE_GNU
+#   endif
+#   include <dlfcn.h>
 #endif
 
 #if defined( ELASTIC_APM_PLATFORM_HAS_LIBUNWIND )


### PR DESCRIPTION
I'm getting some compile errors with PHP 8.2:

```
/home/builder/apm-agent-php/platform.c:40: error: "__USE_GNU" redefined [-Werror]
   40 | #define __USE_GNU
      |
In file included from /home/builder/apm-agent-php/platform.h:27,
                 from /home/builder/apm-agent-php/platform.c:20:
/usr/include/features.h:392: note: this is the location of the previous definition
  392 | # define __USE_GNU 1
      |
```

As mentioned in https://github.com/elastic/apm-agent-php/issues/1008#issuecomment-1624373758 I think this might be a small bug with #1015.