### PR TITLE
Skip Distributed Tracing for WordPress Cron

### DIFF
--- a/agent/php/ElasticApm/Impl/AutoInstrument/CurlHandleTracker.php
+++ b/agent/php/ElasticApm/Impl/AutoInstrument/CurlHandleTracker.php
@@ -428,6 +428,11 @@ final class CurlHandleTracker implements LoggableInterface
 
         $this->setContextPreHook();
 
+        // Special case to skip distributed tracing for WordPress cron.
+        if ($this->url !== null && parse_url($this->url, PHP_URL_PATH) === '/wp-cron.php') {
+            return;
+        }
+
         if ($isHttp) {
             $headersToInjectFormattedLines = [];
             $this->span->injectDistributedTracingHeaders(


### PR DESCRIPTION
WordPress will sometimes make a call to `/wp-cron.php` on shutdown to trigger scheduled actions. These actions are almost never related to the request that makes the request because they simply are just triggered after some time passes until a request gets "lucky". The actions that a WP cronjob ends up doing is also almost never related to the request that ends up triggering it as it's more akin to a deferred jobs system.

Given all this it does not make sense to try and relate the actions of a `/wp-cron.php` call with the request that triggered it via distributed tracing. Here we exit early and skip setting the distributed tracing headers so that WP cron calls show up as seperate transactions not child transactions of some unrelated HTTP call.