### PR TITLE
Documented open_basedir limitation and logging if boostrapper path doesn't comply that limitation

### DIFF
--- a/agent/native/ext/lifecycle.cpp
+++ b/agent/native/ext/lifecycle.cpp
@@ -555,7 +555,7 @@ void elasticApmModuleInit( int moduleType, int moduleNumber )
     elasticapm::php::Hooking::getInstance().replaceHooks();
 
     if (php_check_open_basedir_ex(config->bootstrapPhpPartFile, false) != 0) {
-        ELASTIC_APM_LOG_WARNING( "Elastic Agent bootstrap file (%s) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html", config->bootstrapPhpPartFile);
+        ELASTIC_APM_LOG_WARNING( "Elastic Agent bootstrap file (%s) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html#limitations", config->bootstrapPhpPartFile);
     }
 
     resultCode = resultSuccess;

--- a/agent/native/ext/lifecycle.cpp
+++ b/agent/native/ext/lifecycle.cpp
@@ -554,6 +554,10 @@ void elasticApmModuleInit( int moduleType, int moduleNumber )
 
     elasticapm::php::Hooking::getInstance().replaceHooks();
 
+    if (php_check_open_basedir_ex(config->bootstrapPhpPartFile, false) != 0) {
+        ELASTIC_APM_LOG_WARNING( "Elastic Agent bootstrap file (%s) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html", config->bootstrapPhpPartFile);
+    }
+
     resultCode = resultSuccess;
     finally:
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -101,4 +101,4 @@ the built `elastic_apm-*.so` and the downloaded source files.
 
 === Limitations
 
-Please be aware that if the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] option is configured in your php.ini, the source code of the agent (php part) must be located within a path included in the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] configuration and should be within the directory tree. Otherwise, the agent will not be loaded correctly.
+Please be aware that if the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] option is configured in your php.ini, the installation directory of the agent (by default /opt/elastic/apm-agent/php) must be located within a path included in the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] configuration. Otherwise, the agent will not be loaded correctly.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -98,3 +98,7 @@ and the downloaded source files.
 So if you would like to build `elastic_apm-*.so` on one machine and
 then deploy it on a different machine, you will need to copy both
 the built `elastic_apm-*.so` and the downloaded source files.
+
+=== Limitations
+
+Please be aware that if the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] option is configured in your php.ini, the source code of the agent (php part) must be located within a path included in the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] configuration and should be within the directory tree. Otherwise, the agent will not be loaded correctly.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -100,5 +100,5 @@ then deploy it on a different machine, you will need to copy both
 the built `elastic_apm-*.so` and the downloaded source files.
 
 === Limitations
-
-Please be aware that if the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] option is configured in your php.ini, the installation directory of the agent (by default /opt/elastic/apm-agent/php) must be located within a path included in the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] configuration. Otherwise, the agent will not be loaded correctly.
+[[limitations]]
+Please be aware that if the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] option is configured in your php.ini, the installation directory of the agent (by default /opt/elastic/apm-agent-php) must be located within a path included in the https://www.php.net/manual/en/ini.core.php#ini.open-basedir[open_basedir] configuration. Otherwise, the agent will not be loaded correctly.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -68,7 +68,7 @@ Also see <<dev-internal-config-disclaimer>>.
 
 ==== open_basedir issue
 
-If you see a similar entry in the agent log, this indicates an incorrect open_basedir configuration. Please read the details https://www.elastic.co/guide/en/apm/agent/php/current/setup.html#limitations[here]
+If you see a similar entry in the agent log, this indicates an incorrect open_basedir configuration. Please read the details in the <<limitations, limitations>>
 ----
 [Elastic APM PHP Tracer] 2023-08-23 14:38:12.223397+02:00 [PID: 268995] [TID: 268995] [WARNING]  [Lifecycle] [lifecycle.cpp:558] [elasticApmModuleInit] Elastic Agent bootstrap file (/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html
 ----

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -62,3 +62,13 @@ to enable verbose log for the agent's communication with Elastic APM Server.
 The log is written under `INFO` level - see <<configure-logging>>.
 
 Also see <<dev-internal-config-disclaimer>>.
+
+=== Agent is not instrumenting code
+[source,bash]
+
+==== open_basedir issue
+
+If you see a similar entry in the agent log, this indicates an incorrect open_basedir configuration. Please read the details https://www.elastic.co/guide/en/apm/agent/php/current/setup.html#limitations[here]
+----
+[Elastic APM PHP Tracer] 2023-08-23 14:38:12.223397+02:00 [PID: 268995] [TID: 268995] [WARNING]  [Lifecycle] [lifecycle.cpp:558] [elasticApmModuleInit] Elastic Agent bootstrap file (/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html
+----


### PR DESCRIPTION
It will produce output like this for default log level.
```
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.223397+02:00 [PID: 268995] [TID: 268995] [WARNING]  [Lifecycle] [lifecycle.cpp:558] [elasticApmModuleInit] Elastic Agent bootstrap file (/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php) is located outside of paths allowed by open_basedir ini setting. Read more details here https://www.elastic.co/guide/en/apm/agent/php/current/setup.html
PHP Warning:  PHP Request Startup: open_basedir restriction in effect. File(/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php) is not within the allowed path(s): (/var/www/html/dupa) in Unknown on line 0
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226372+02:00 [PID: 268995] [TID: 268995] [ERROR]    [Util] [util_for_PHP.cpp:94] [loadPhpFile] php_stream_open_for_zend_ex() failed. Return value: -1. phpFilePath: `/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php'
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226396+02:00 [PID: 268995] [TID: 268995] [ERROR]    [Util] [util_for_PHP.cpp:44] [logDiagnostics_for_failed_php_stream_open_for_zend_ex] Diagnostics for failed php_stream_open_for_zend_ex(): fopen("/home/paplo/sources/apm-agent-php/agent/php/bootstrap_php_part.php", "r") returned non-NULL value
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226409+02:00 [PID: 268995] [TID: 268995] [ERROR]    [Util] [util_for_PHP.cpp:171] [loadPhpFile] Exiting...; resultCode: resultFailure (6); 
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226415+02:00 [PID: 268995] [TID: 268995] [ERROR]    [C-to-PHP] [tracer_PHP_part.cpp:90] [switchTracerPhpPartStateToFailed] Switching tracer PHP part state to failed; reason: Failed to bootstrap tracer PHP part, current state: tracerPhpPartState_before_bootstrap, called from bootstrapTracerPhpPart
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226425+02:00 [PID: 268995] [TID: 268995] [ERROR]    [C-to-PHP] [tracer_PHP_part.cpp:155] [bootstrapTracerPhpPart] Exiting...; resultCode: resultFailure (6); 
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226431+02:00 [PID: 268995] [TID: 268995] [ERROR]    [Lifecycle] [lifecycle.cpp:758] [elasticApmRequestInit] Exiting...; resultCode: resultFailure (6); 
...
[Elastic APM PHP Tracer] 2023-08-23 14:38:12.226747+02:00 [PID: 268995] [TID: 268995] [ERROR]    [C-to-PHP] [tracer_PHP_part.cpp:184] [shutdownTracerPhpPart] Exiting...; resultCode: resultFailure (6); 

```