### PR TITLE
action: create mandatory GH check for docs

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,28 @@
+# This workflow sets the test / all status check to success in case it's a docs only PR and test.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: test # The name must be the same as in test.yml
+
+on:
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on main.yml.
+      - '**'
+      - '!**/*.md'
+      - '!**/*.asciidoc'
+      - '!**/*.png'
+
+permissions:
+  contents: read
+
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+
+jobs:
+  # dummy steps that allow to bypass those mandatory checks for tests
+  build-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -19,10 +19,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-
 jobs:
   # dummy steps that allow to bypass those mandatory checks for tests
   build-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'
+
+  # dummy steps that allow to bypass those mandatory checks for tests
+  ci:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Not required for docs"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           name: package-parts-linuxmusl-x86-64
           path: agent/native/_build/linuxmusl-x86-64-release/ext
-          
+
       - if: ${{ env.TESTING_TYPE == 'lifecycle' }}
         name: lifecycle test
         run: |
@@ -247,3 +247,13 @@ jobs:
         with:
           name: syslogs
           path: build/syslog-files/
+
+  # The very last job to report whether the Workflow passed.
+  # This will act as the Branch Protection gatekeeper
+  ci:
+    needs:
+      - test-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: report
+        run: echo "CI workflow passed"


### PR DESCRIPTION
`test-docs` is the way we can ensure docs are creating GH checks that are mandatory

`ci` GitHub check will be the one used as Branch protection gatekeeper. This will be done later on, once all the open PRs are rebased with this change
