### PR TITLE
Enable possibility to build agent locally for aarch64

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,11 +6,17 @@
 If you don't want to install any of the dependencies you might need to compile and install the library then you can use the Dockerfile.
 
 ```bash
-## To compile the library for all supported PHP releases for glibc Linux distributions
+## To compile the library for all supported PHP releases for glibc Linux distributions for x86_64 architecture
 BUILD_ARCHITECTURE=linux-x86-64 make -f .ci/Makefile build
 
-## To compile the library for all supported PHP releases for musl libc Linux distributions
+## To compile the library for all supported PHP releases for musl libc Linux distributions for x86_64 architecture
 BUILD_ARCHITECTURE=linuxmusl-x86-64 make -f .ci/Makefile build
+
+## To compile the library for all supported PHP releases for glibc Linux distributions for aarch64 (ARMv8) architecture. This build is not officially supported.
+BUILD_ARCHITECTURE=linux-arm64 make -f .ci/Makefile build
+
+## To compile the library for all supported PHP releases for musl libc Linux distributions for aarch64 (ARMv8) architecture. This build is not officially supported.
+BUILD_ARCHITECTURE=linuxmusl-arm64 make -f .ci/Makefile build
 
 ## To prepare the docker container for testing
 PHP_VERSION=7.2 make -f .ci/Makefile prepare

--- a/agent/native/CMakeLists.txt
+++ b/agent/native/CMakeLists.txt
@@ -30,7 +30,7 @@ if(EXISTS /etc/alpine-release)
     set(MUSL_BUILD true)
 endif()
 
-if ((NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64"))
+if ((NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" AND NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64"))
      message(FATAL_ERROR "System or architecture not supported")
 endif()
 

--- a/agent/native/CMakeLists.txt
+++ b/agent/native/CMakeLists.txt
@@ -87,11 +87,15 @@ endforeach()
 
 set(dependencies
     "libcurl/8.0.1"
-    "cmocka/1.1.5@"
     "libunwind/1.6.2"
 #    "boost/1.82.0"
     "gtest/1.13.0"
 )
+
+# cmocka has issues on arm64
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+    list(APPEND dependencies "cmocka/1.1.5@")
+endif()
 
 foreach(_php_version ${_supported_php_versions})
    list(APPEND dependencies "php-headers-${_php_version}/1.0@elastic/local")

--- a/agent/native/CMakePresets.json
+++ b/agent/native/CMakePresets.json
@@ -101,7 +101,23 @@
             "debug",
             "binutils"
         ]
-	}
+	},
+    {
+        "name": "linux-arm64-release",
+        "inherits": [
+            "os-type-unix",
+            "release",
+            "binutils"
+        ]
+    },
+    {
+        "name": "linux-arm64-debug",
+        "inherits": [
+            "os-type-unix",
+            "debug",
+            "binutils"
+        ]
+    }
     ],
     "buildPresets": [
     {
@@ -142,6 +158,20 @@
     {
         "name": "linuxmusl-x86-64-release",
         "configurePreset": "linuxmusl-x86-64-release",
+        "inherits": [
+            "release"
+        ]
+    },
+    {
+        "name": "linux-arm64-debug",
+        "configurePreset": "linux-arm64-debug",
+        "inherits": [
+            "debug"
+        ]
+    },
+    {
+        "name": "linux-arm64-release",
+        "configurePreset": "linux-arm64-release",
         "inherits": [
             "release"
         ]
@@ -191,7 +221,20 @@
             "inherits": [
                 "release"
             ]
+        },
+        {
+            "name": "linux-arm64-debug",
+            "configurePreset": "linux-arm64-debug",
+            "inherits": [
+                "debug"
+            ]
+        },
+        {
+            "name": "linux-arm64-release",
+            "configurePreset": "linux-arm64-release",
+            "inherits": [
+                "release"
+            ]
         }
-
     ]
   }

--- a/agent/native/CMakePresets.json
+++ b/agent/native/CMakePresets.json
@@ -191,6 +191,20 @@
         "inherits": [
             "release"
         ]
+    },
+    {
+        "name": "linuxmusl-arm64-debug",
+            "configurePreset": "linuxmusl-arm64-debug",
+            "inherits": [
+	            "debug"
+        ]
+    },
+    {
+        "name": "linuxmusl-arm64-release",
+        "configurePreset": "linuxmusl-arm64-release",
+        "inherits": [
+            "release"
+        ]
     }
     ],
     "testPresets": [

--- a/agent/native/CMakePresets.json
+++ b/agent/native/CMakePresets.json
@@ -117,7 +117,23 @@
             "debug",
             "binutils"
         ]
-    }
+    },
+    {
+        "name": "linuxmusl-arm64-release",
+        "inherits": [
+            "os-type-unix",
+            "release",
+            "binutils"
+        ]
+    },
+    {
+        "name": "linuxmusl-arm64-debug",
+        "inherits": [
+            "os-type-unix",
+            "debug",
+            "binutils"
+        ]
+    }    
     ],
     "buildPresets": [
     {
@@ -235,6 +251,20 @@
             "inherits": [
                 "release"
             ]
-        }
+        },
+        {
+            "name": "linuxmusl-arm64-debug",
+            "configurePreset": "linux-arm64-debug",
+            "inherits": [
+                "debug"
+            ]
+        },
+        {
+            "name": "linuxmusl-arm64-release",
+            "configurePreset": "linux-arm64-release",
+            "inherits": [
+                "release"
+            ]
+        }        
     ]
   }

--- a/agent/native/building/cmake/elastic_conan_installer.cmake
+++ b/agent/native/building/cmake/elastic_conan_installer.cmake
@@ -39,6 +39,17 @@ execute_process(
 
 set(_PRV_CONAN_PROFILE_OS ${CMAKE_SYSTEM_NAME})
 
+
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+    set(_PRV_CONAN_PROFILE_ARCH "arch=armv8")
+    set(_PRV_CONAN_PROFILE_ARCH_BUILD "arch_build=armv8")
+elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(_PRV_CONAN_PROFILE_ARCH "arch=x86_64")
+    set(_PRV_CONAN_PROFILE_ARCH_BUILD "arch_build=x86_64")
+else()
+    message(FATAL_ERROR "CPU Architecure not supported ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
 if (MUSL_BUILD)
     #this is workaround to force build from souce on musl - this will prevent from installing libc binaries
     set(_PRV_CONAN_PROFILE_OS_DISTRO "os.distro=Alpine")
@@ -49,7 +60,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    message(STATUS "Linux ${_PRV_CONAN_PROFILE_OS_DISTRO}, ${_PRV_COMPILER_LIBC_IMPLEMENTATION}")
+    message(STATUS "Linux ${_PRV_CONAN_PROFILE_OS_DISTRO}, ${_PRV_COMPILER_LIBC_IMPLEMENTATION}, ${_PRV_CONAN_PROFILE_ARCH_BUILD}")
 endif()
 
 # setting up paths used to configure compiler profile

--- a/agent/native/building/conan/conan_profile.in
+++ b/agent/native/building/conan/conan_profile.in
@@ -2,8 +2,8 @@
 [settings]
 os=@_PRV_CONAN_PROFILE_OS@
 @_PRV_CONAN_PROFILE_OS_DISTRO@
-arch=x86_64
-arch_build=x86_64
+@_PRV_CONAN_PROFILE_ARCH@
+@_PRV_CONAN_PROFILE_ARCH_BUILD@
 build_type=Release
 compiler=@_PRV_COMPILER_NAME@
 compiler.version=@_PRV_COMPILER_VERSION_SHORT@

--- a/agent/native/building/dockerized/docker-compose.yml
+++ b/agent/native/building/dockerized/docker-compose.yml
@@ -34,4 +34,4 @@ services:
         image: elasticobservability/apm-agent-php-dev:native-build-gcc-12.2.0-linuxmusl-arm64-0.0.2
         volumes:
           - ../../../../:/source
-        command: sh -c "cd /source/agent/native && cmake --preset linux-arm64-release && cmake --build --preset linux-arm64-release"
+        command: sh -c "cd /source/agent/native && cmake --preset linuxmusl-arm64-release && cmake --build --preset linuxmusl-arm64-release"

--- a/agent/native/building/dockerized/docker-compose.yml
+++ b/agent/native/building/dockerized/docker-compose.yml
@@ -26,3 +26,12 @@ services:
         volumes:
           - ../../../../:/source
         command: sh -c "cd /source/agent/native && cmake --preset linux-arm64-release && cmake --build --preset linux-arm64-release"
+
+    build_apm_php_arm64_musl:
+        build:
+            context: .
+            dockerfile: images/Dockerfile_arm64_musl
+        image: elasticobservability/apm-agent-php-dev:native-build-gcc-12.2.0-linuxmusl-arm64-0.0.2
+        volumes:
+          - ../../../../:/source
+        command: sh -c "cd /source/agent/native && cmake --preset linux-arm64-release && cmake --build --preset linux-arm64-release"

--- a/agent/native/building/dockerized/docker-compose.yml
+++ b/agent/native/building/dockerized/docker-compose.yml
@@ -17,3 +17,12 @@ services:
         volumes:
           - ../../../../:/source
         command: sh -c "cd /source/agent/native && cmake --preset linuxmusl-x86-64-release && cmake --build --preset linuxmusl-x86-64-release"
+
+    build_apm_php_arm64:
+        build:
+            context: .
+            dockerfile: images/Dockerfile_arm64
+        image: elasticobservability/apm-agent-php-dev:native-build-gcc-12.2.0-linux-arm64-0.0.2
+        volumes:
+          - ../../../../:/source
+        command: sh -c "cd /source/agent/native && cmake --preset linux-arm64-release && cmake --build --preset linux-arm64-release"

--- a/agent/native/building/dockerized/images/Dockerfile_arm64
+++ b/agent/native/building/dockerized/images/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04 as devtools
+FROM arm64v8/centos:7 as devtools
 
 ARG GCC_VERSION=12.2.0
 ARG BINUTILS_VERSION=2.40
@@ -8,12 +8,14 @@ ARG USER_NAME=build
 
 #binutils: bison - gprofng, texinfo - makeinfo
 
-RUN apt-get update && apt-get -y install sudo curl wget git make autoconf bzip2 \
+RUN yum -y update && yum -y install centos-release-scl
+RUN yum -y install sudo curl wget git make autoconf bzip2 \
     texinfo bison \
     python3 python3-pip python3-venv \
-    binutils gcc libz-dev
+    devtoolset-7-binutils devtoolset-7-gcc  devtoolset-7-gcc-c++ zlib-devel
 
-RUN adduser --disabled-password --gecos "" ${USER_NAME} \
+RUN adduser -p password ${USER_NAME} \
+    && passwd -d ${USER_NAME} \
     && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER ${USER_NAME}
@@ -25,10 +27,11 @@ RUN curl -LO https://gcc.gnu.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_V
  && tar -xf gcc-${GCC_VERSION}.tar.xz \
  && rm gcc-${GCC_VERSION}.tar.xz
 
-RUN cd gcc-${GCC_VERSION} \
+RUN source scl_source enable devtoolset-7 \
+ && cd gcc-${GCC_VERSION} \
  && ./contrib/download_prerequisites \
  && CFG_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete \
- --disable-libstdcxx-visibility --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib \ 
+ --disable-libstdcxx-visibility --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib \
  --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu" \
  && echo $CFG_OPTIONS \
  && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CFG_OPTIONS \
@@ -41,7 +44,8 @@ RUN curl -LO https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.x
  && tar -xf binutils-${BINUTILS_VERSION}.tar.xz \
  && rm binutils-${BINUTILS_VERSION}.tar.xz 
 
-RUN cd binutils-${BINUTILS_VERSION} \
+RUN source scl_source enable devtoolset-7 \
+ && cd binutils-${BINUTILS_VERSION} \
  && ./configure --prefix=/opt/binutils-${BINUTILS_VERSION} CFLAGS=-Wno-unused-value --enable-gold \
  && make -j$(nproc) \
  && sudo make install \
@@ -58,18 +62,21 @@ RUN curl -LO https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON
  && tar -xf Python-${PYTHON_VERSION}.tgz \
  && rm Python-${PYTHON_VERSION}.tgz
 
-#RUN sudo apt-get -y install libffi-dev openssl-dev sqlite-dev readline-dev xz-dev bzip2-dev
+RUN sudo yum -y install libffi-devel openssl-devel sqlite-devel readline-devel xz-devel bzip2-devel
 
-RUN cd Python-${PYTHON_VERSION} \
+RUN source scl_source enable devtoolset-7 \
+ && cd Python-${PYTHON_VERSION} \
  && ./configure --help \
  && ./configure --enable-optimizations --prefix=/opt/python-${PYTHON_VERSION} \
  && make \
  && sudo make install
 
-RUN sudo apt-get clean
+
+RUN sudo yum -y remove devtoolset-7* centos-release-scl \
+ && sudo yum -y clean all
 
 
-FROM arm64v8/ubuntu:18.04
+FROM arm64v8/centos:7
 
 ARG GCC_VERSION=12.2.0
 ARG BINUTILS_VERSION=2.40
@@ -79,9 +86,13 @@ ARG USER_NAME=build
 
 COPY --from=devtools /opt /opt
 
-RUN apt-get -y update && apt-get -y install sudo curl wget git make autoconf bzip2 file libc-dev
+RUN yum -y update && yum -y install sudo curl wget git make autoconf bzip2 \
+    perl-Thread-Queue perl-IPC-Cmd perl-Digest-SHA \
+    file \
+    glibc-devel
 
-RUN adduser --disabled-password --gecos "" ${USER_NAME} \
+RUN adduser -p password ${USER_NAME} \
+    && passwd -d ${USER_NAME} \
     && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER ${USER_NAME}

--- a/agent/native/building/dockerized/images/Dockerfile_arm64
+++ b/agent/native/building/dockerized/images/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM centos:7 as devtools
+FROM arm64v8/ubuntu:18.04 as devtools
 
 ARG GCC_VERSION=12.2.0
 ARG BINUTILS_VERSION=2.40
@@ -8,14 +8,12 @@ ARG USER_NAME=build
 
 #binutils: bison - gprofng, texinfo - makeinfo
 
-RUN yum -y update && yum -y install centos-release-scl
-RUN yum -y install sudo curl wget git make autoconf bzip2 \
+RUN apt-get update && apt-get -y install sudo curl wget git make autoconf bzip2 \
     texinfo bison \
     python3 python3-pip python3-venv \
-    devtoolset-7-binutils devtoolset-7-gcc  devtoolset-7-gcc-c++ zlib-devel
+    binutils gcc libz-dev
 
-RUN adduser -p password ${USER_NAME} \
-    && passwd -d ${USER_NAME} \
+RUN adduser --disabled-password --gecos "" ${USER_NAME} \
     && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER ${USER_NAME}
@@ -27,12 +25,11 @@ RUN curl -LO https://gcc.gnu.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_V
  && tar -xf gcc-${GCC_VERSION}.tar.xz \
  && rm gcc-${GCC_VERSION}.tar.xz
 
-RUN source scl_source enable devtoolset-7 \
- && cd gcc-${GCC_VERSION} \
+RUN cd gcc-${GCC_VERSION} \
  && ./contrib/download_prerequisites \
  && CFG_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete \
- --disable-libstdcxx-visibility --with-tune=generic --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib \
- --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu" \
+ --disable-libstdcxx-visibility --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib \ 
+ --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu" \
  && echo $CFG_OPTIONS \
  && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CFG_OPTIONS \
  && make -j$(nproc) \
@@ -44,39 +41,35 @@ RUN curl -LO https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.x
  && tar -xf binutils-${BINUTILS_VERSION}.tar.xz \
  && rm binutils-${BINUTILS_VERSION}.tar.xz 
 
-RUN source scl_source enable devtoolset-7 \
- && cd binutils-${BINUTILS_VERSION} \
+RUN cd binutils-${BINUTILS_VERSION} \
  && ./configure --prefix=/opt/binutils-${BINUTILS_VERSION} CFLAGS=-Wno-unused-value --enable-gold \
  && make -j$(nproc) \
  && sudo make install \
  && cd - \
  && rm -rf binutils-${BINUTILS_VERSION}
 
-RUN curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
- && chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh \
+RUN curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh \
+ && chmod +x cmake-${CMAKE_VERSION}-linux-aarch64.sh \
  && sudo mkdir -p /opt/cmake-${CMAKE_VERSION} \
- && sudo ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/opt/cmake-${CMAKE_VERSION} \
- && rm cmake-${CMAKE_VERSION}-linux-x86_64.sh
+ && sudo ./cmake-${CMAKE_VERSION}-linux-aarch64.sh --skip-license --prefix=/opt/cmake-${CMAKE_VERSION} \
+ && rm cmake-${CMAKE_VERSION}-linux-aarch64.sh
 
 RUN curl -LO https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
  && tar -xf Python-${PYTHON_VERSION}.tgz \
  && rm Python-${PYTHON_VERSION}.tgz
 
-RUN sudo yum -y install libffi-devel openssl-devel sqlite-devel readline-devel xz-devel bzip2-devel
+#RUN sudo apt-get -y install libffi-dev openssl-dev sqlite-dev readline-dev xz-dev bzip2-dev
 
-RUN source scl_source enable devtoolset-7 \
- && cd Python-${PYTHON_VERSION} \
+RUN cd Python-${PYTHON_VERSION} \
  && ./configure --help \
  && ./configure --enable-optimizations --prefix=/opt/python-${PYTHON_VERSION} \
  && make \
  && sudo make install
 
-
-RUN sudo yum -y remove devtoolset-7* centos-release-scl \
- && sudo yum -y clean all
+RUN sudo apt-get clean
 
 
-FROM centos:7
+FROM arm64v8/ubuntu:18.04
 
 ARG GCC_VERSION=12.2.0
 ARG BINUTILS_VERSION=2.40
@@ -86,13 +79,9 @@ ARG USER_NAME=build
 
 COPY --from=devtools /opt /opt
 
-RUN yum -y update && yum -y install sudo curl wget git make autoconf bzip2 \
-    perl-Thread-Queue perl-IPC-Cmd perl-Digest-SHA \
-    file \
-    glibc-devel
+RUN apt-get -y update && apt-get -y install sudo curl wget git make autoconf bzip2 file libc-dev
 
-RUN adduser -p password ${USER_NAME} \
-    && passwd -d ${USER_NAME} \
+RUN adduser --disabled-password --gecos "" ${USER_NAME} \
     && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER ${USER_NAME}

--- a/agent/native/building/dockerized/images/Dockerfile_arm64_musl
+++ b/agent/native/building/dockerized/images/Dockerfile_arm64_musl
@@ -29,7 +29,7 @@ RUN cd gcc-${GCC_VERSION} \
  && ./contrib/download_prerequisites \
  && CFG_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete \
  --disable-libstdcxx-visibility --with-tune=generic --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib --disable-libsanitizer \
- --build=aarch64-linux-musl --host=aarch64-linux-musl --target=aarch64-linux-musl" \
+ --build=aarch64-alpine-linux-musl --host=aarch64-alpine-linux-musl --target=aarch64-alpine-linux-musl" \
  && echo $CFG_OPTIONS \
  && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CFG_OPTIONS \
  && make -j$(nproc) \

--- a/agent/native/building/dockerized/images/Dockerfile_arm64_musl
+++ b/agent/native/building/dockerized/images/Dockerfile_arm64_musl
@@ -1,0 +1,83 @@
+FROM arm64v8/alpine:3.10 as devtools_alpine
+
+ARG GCC_VERSION=12.2.0
+ARG BINUTILS_VERSION=2.40
+ARG CMAKE_VERSION=3.26.3
+ARG USER_NAME=build
+
+#binutils: bison - gprofng, texinfo - makeinfo
+
+RUN apk update \
+    && apk add sudo curl wget git make autoconf bzip2 \
+    texinfo bison \
+    binutils gcc g++ zlib-dev gettext-dev linux-headers
+
+RUN adduser --disabled-password --gecos '' ${USER_NAME} \
+    && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
+
+USER ${USER_NAME}
+
+RUN mkdir -p /home/${USER_NAME}/prerequisities
+WORKDIR /home/${USER_NAME}/prerequisities
+
+RUN curl -LO https://gcc.gnu.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz \
+ && tar -xf gcc-${GCC_VERSION}.tar.xz \
+ && rm gcc-${GCC_VERSION}.tar.xz
+
+
+RUN cd gcc-${GCC_VERSION} \
+ && ./contrib/download_prerequisites \
+ && CFG_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete \
+ --disable-libstdcxx-visibility --with-tune=generic --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib --disable-libsanitizer \
+ --build=aarch64-linux-musl --host=aarch64-linux-musl --target=aarch64-linux-musl" \
+ && echo $CFG_OPTIONS \
+ && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CFG_OPTIONS \
+ && make -j$(nproc) \
+ && sudo make install \
+ && cd - \
+ && rm -rf gcc-${GCC_VERSION}
+
+RUN curl -LO https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz \
+ && tar -xf binutils-${BINUTILS_VERSION}.tar.xz \
+ && rm binutils-${BINUTILS_VERSION}.tar.xz 
+
+RUN cd binutils-${BINUTILS_VERSION} \
+ && ./configure --help \
+ && ./configure --prefix=/opt/binutils-${BINUTILS_VERSION} --enable-gold  --build=aarch64-linux-musl --host=aarch64-linux-musl --target=aarch64-linux-musl --enable-shared --disable-multilib --with-system-zlib --enable-install-libiberty  --disable-gprofng --enable-ld=default --enable-64-bit-bfd --enable-relro --enable-deterministic-archives --enable-default-execstack=no --enable-default-hash-style=gnu --with-pic  --disable-werror --disable-nls --with-mmap  \ 
+ && make -j$(nproc) \
+ && sudo make install \
+ && cd - \
+ && rm -rf binutils-${BINUTILS_VERSION}
+
+RUN curl -LO https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
+ && tar -xf cmake-${CMAKE_VERSION}.tar.gz \
+ && rm cmake-${CMAKE_VERSION}.tar.gz 
+
+RUN sudo apk add curl-dev
+
+RUN cd cmake-${CMAKE_VERSION} \
+ && ./bootstrap --prefix=/opt/cmake-${CMAKE_VERSION} --parallel="${nproc:-2}"\
+ && make -j$(nproc)\
+ && sudo make install
+
+FROM arm64v8/alpine:3.10
+
+COPY --from=devtools_alpine /opt /opt
+
+ARG GCC_VERSION=12.2.0
+ARG BINUTILS_VERSION=2.40
+ARG CMAKE_VERSION=3.26.3
+ARG USER_NAME=build
+
+RUN apk add --no-cache sudo curl wget git make autoconf bzip2 \
+    libstdc++ libintl icu musl-dev curl-dev linux-headers \
+    python3 py3-pip py3-virtualenv bash
+
+RUN adduser --disabled-password --gecos '' ${USER_NAME} \
+    && echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
+
+USER ${USER_NAME}
+
+ENV PATH="/opt/binutils-${BINUTILS_VERSION}/bin:/opt/cmake-${CMAKE_VERSION}/bin:${PATH}"
+ENV CMAKE_INSTALL_PREFIX=/opt/cmake-${CMAKE_VERSION}
+ 

--- a/agent/native/building/dockerized/images/Dockerfile_musl
+++ b/agent/native/building/dockerized/images/Dockerfile_musl
@@ -27,12 +27,11 @@ RUN curl -LO https://gcc.gnu.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_V
 
 RUN cd gcc-${GCC_VERSION} \
  && ./contrib/download_prerequisites \
- && SHARED_CONFIGURE_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete" \
- && SHARED_CONFIGURE_OPTIONS="$SHARED_CONFIGURE_OPTIONS --disable-libstdcxx-visibility" \
- && CONFIGURE_OPTIONS="$SHARED_CONFIGURE_OPTIONS --with-tune=generic --enable-libstdcxx-debug-flags=-gdwarf-2" \
- && CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --build=x86_64-linux-musl --host=x86_64-linux-musl --target=x86_64-linux-musl --disable-multilib --disable-libsanitizer" \
- && echo $CONFIGURE_OPTIONS \
- && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CONFIGURE_OPTIONS \
+ && CFG_OPTIONS="--enable-languages=c,c++ --enable-shared --enable-linker-build-id --with-system-zlib --without-included-gettext --enable-threads=posix --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --disable-werror --enable-checking=release --with-pic --disable-symvers --enable-obsolete \
+ --disable-libstdcxx-visibility --with-tune=generic --enable-libstdcxx-debug-flags=-gdwarf-2 --disable-multilib --disable-libsanitizer \
+ --build=x86_64-linux-musl --host=x86_64-linux-musl --target=x86_64-linux-musl" \
+ && echo $CFG_OPTIONS \
+ && ./configure --prefix=/opt/gcc-${GCC_VERSION} $CFG_OPTIONS \
  && make -j$(nproc) \
  && sudo make install \
  && cd - \

--- a/agent/native/ext/CMakeLists.txt
+++ b/agent/native/ext/CMakeLists.txt
@@ -77,5 +77,7 @@ foreach(_php_version ${_supported_php_versions})
 
 endforeach()
 
-
-add_subdirectory(unit_tests)
+# cmocka has issues on arm64
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+    add_subdirectory(unit_tests)
+endif()


### PR DESCRIPTION
Prepared compiler docker images for aarch64 (ARMv8) linux with glibc (most Linux distributions and for musl-libc (Alpine)

To build agent for glibc linux distributions call:
```BUILD_ARCHITECTURE=linux-arm64 make -f .ci/Makefile build```

To build agent for musl-libc linux distributions (Alpine) call:
```BUILD_ARCHITECTURE=linuxmusl-arm64 make -f .ci/Makefile build```


Disabled build of problematic cmocka tests
