### PR TITLE
action: listen for tags creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ permissions:
   contents: read
 
 on:
-  create:
-    tags: [ "v*" ]
+  push:
+    tags: [ "v[0-9]+*" ]
 
 jobs:
 


### PR DESCRIPTION
otherwise it won't be triggered when running git tag and git push