### PR TITLE
action: support packages for signed/unsigned and fix release checksum validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
     with:
       include: ${{ needs.generate-test-packages-matrix.outputs.include }}
       max-parallel: 40
+      package-name: 'signed-artifacts'
 
   release:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   push:
     tags: [ "v[0-9]+*" ]
 
+env:
+  BUILD_PACKAGES: build/packages
+
 jobs:
 
   release-started:
@@ -41,13 +44,12 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: package
-          path: build/packages
+          path: ${{ env.BUILD_PACKAGES }}
 
       ## NOTE: The name of the zip should match the name of the folder to be zipped.
       - name: Prepare packages to be signed
-        run: |-
-          cd build
-          zip -r packages.zip packages/
+        run: zip -r packages.zip packages/
+        working-directory: build
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.7.3
@@ -67,7 +69,7 @@ jobs:
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: "build/packages.zip"
+          path: "${{ env.BUILD_PACKAGES }}.zip"
           destination: "${{ env.BUCKET_NAME }}/${{ github.run_id }}"
           predefinedAcl: "publicRead"
 
@@ -115,19 +117,17 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: signed-artifacts
-          path: build/packages
+          path: ${{ env.BUILD_PACKAGES }}
 
       - name: Unzip signed packages
-        run: |-
-          cd build/packages
-          unzip signed-artifacts.zip
-          rm signed-artifacts.zip
+        run: unzip signed-artifacts.zip && rm signed-artifacts.zip
+        working-directory: ${{ env.BUILD_PACKAGES }}
 
       - name: Create draft release
         run: make -f .ci/Makefile draft-release
 
       - name: Verify draft release
-        run: ORIGINAL_PACKAGES_LOCATION=build/packages make -f .ci/Makefile download-verify
+        run: ORIGINAL_PACKAGES_LOCATION=${{ env.BUILD_PACKAGES }} make -f .ci/Makefile download-verify
 
       - name: Publish release
         run: make -f .ci/Makefile github-release-ready

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           echo "RELEASE_ID=$(make -f .ci/Makefile get-draft-release)" >> $GITHUB_ENV
 
       - name: Verify draft release
-        run: ORIGINAL_PACKAGES_LOCATION=build/packagesmake -f .ci/Makefile download-verify
+        run: ORIGINAL_PACKAGES_LOCATION=build/packages make -f .ci/Makefile download-verify
 
       - name: Publish release
         run: make -f .ci/Makefile github-release-ready

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,7 @@ jobs:
           unzip signed-artifacts.zip
 
       - name: Create draft release
-        run: |-
-          make -f .ci/Makefile draft-release
-          echo "RELEASE_ID=$(make -f .ci/Makefile get-draft-release)" >> $GITHUB_ENV
+        run: make -f .ci/Makefile draft-release
 
       - name: Verify draft release
         run: ORIGINAL_PACKAGES_LOCATION=build/packages make -f .ci/Makefile download-verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         run: |-
           cd build/packages
           unzip signed-artifacts.zip
+          rm signed-artifacts.zip
 
       - name: Create draft release
         run: make -f .ci/Makefile draft-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,10 @@ jobs:
           path: ${{ env.BUILD_PACKAGES }}
 
       - name: Unzip signed packages
-        run: unzip signed-artifacts.zip && rm signed-artifacts.zip
+        run: unzip ${PACKAGE_FILE} && rm ${PACKAGE_FILE}
         working-directory: ${{ env.BUILD_PACKAGES }}
+        env:
+          PACKAGE_FILE: "signed-artifacts.zip"
 
       - name: Create draft release
         run: make -f .ci/Makefile draft-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           channel: "#apm-agent-php"
           message: |
-            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered : (<${{ steps.buildkite.outputs.build }}|here> for further details)
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered : (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here> for further details)
 
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,18 @@ on:
 
 jobs:
 
+  release-started:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-php"
+          message: |
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered : (<${{ steps.buildkite.outputs.build }}|here> for further details)
+
   build:
     uses: ./.github/workflows/build.yml
 

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -14,6 +14,11 @@ on:
         default: 20
         required: false
         type: number
+      package-name:
+        description: 'The artifact name with the binaries to be tested'
+        default: "package"
+        required: false
+        type: string
 
 jobs:
   test-packages:
@@ -34,8 +39,15 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: package
+          name: ${{ inputs.package-name }}
           path: build/packages
+
+      ## This will help with preparing the signed artifacts that were bundled in a zip file
+      - if: ${{ inputs.package-name == 'signed-artifacts' }}
+        name: Unzip signed packages
+        run: |-
+          cd build/packages
+          unzip ${{ inputs.package-name }}.zip
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -34,25 +34,28 @@ jobs:
       LINUX_PACKAGE_TYPE: ${{ matrix.item[1] }}
       TESTING_TYPE: ${{ matrix.item[2] }}
       ELASTIC_APM_PHP_TESTS_MATRIX_ROW: "${{ join(matrix.item, ',') }}"
+      BUILD_PACKAGES: build/packages
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.package-name }}
-          path: build/packages
+          path: ${{ env.BUILD_PACKAGES }}
 
       ## This will help with preparing the signed artifacts that were bundled in a zip file
       - if: ${{ inputs.package-name == 'signed-artifacts' }}
         name: Unzip signed packages
-        run: |-
-          cd build/packages
-          unzip ${{ inputs.package-name }}.zip
+        run: unzip ${PACKAGE_FILE} && rm ${PACKAGE_FILE}
+        working-directory: ${{ env.BUILD_PACKAGES }}
+        env:
+          PACKAGE_FILE: "${{ inputs.package-name }}.zip"
 
       - uses: actions/download-artifact@v3
         with:
           name: package-parts-linux-x86-64
           path: agent/native/_build/linux-x86-64-release/ext
+
       - uses: actions/download-artifact@v3
         with:
           name: package-parts-linuxmusl-x86-64
@@ -82,10 +85,10 @@ jobs:
       - if: ${{ env.TESTING_TYPE == 'agent-upgrade' }}
         name: agent upgrade test - prepare
         run: |
-          mv build/packages build/backup
+          mv ${{ env.BUILD_PACKAGES }} build/backup
           VERSION=1.0.0 make -C packaging package
-          mv build/packages build/local
-          mv build/backup build/packages
+          mv ${{ env.BUILD_PACKAGES }} build/local
+          mv build/backup ${{ env.BUILD_PACKAGES }}
           make -C packaging "${LINUX_PACKAGE_TYPE}-agent-upgrade-testing-local"
 
       - if: success() || failure()


### PR DESCRIPTION
Fixing some issues that have been discovered when trying the release [`v1.10.0`](https://github.com/elastic/apm-agent-php/releases/tag/v1.10.0):

* Support test-packages with the signed artifacts in addition to the unsigned artifacts.
* Fix typo in ` Verify draft release`
* Remove unrequired `echo "RELEASE_ID=$(make -f .ci/Makefile get-draft-release)" >> $GITHUB_ENV`
* Notify when the release has started

### Test

I created a test branch based on this PR but using a different slack channel and skipped the release steps 

<details><summary>Expand to view diff</summary>
<p>

```diff
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
index fa85af04..f4bc8eb5 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ permissions:
 
 on:
   push:
-    tags: [ "v[0-9]+*" ]
 
 env:
   BUILD_PACKAGES: build/packages
@@ -21,7 +20,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-php"
+          channel: "#on-week-oblt-productivity"
           message: |
             :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered : (<${{ steps.buildkite.outputs.build }}|here> for further details)
 
@@ -126,13 +125,13 @@ jobs:
           PACKAGE_FILE: "signed-artifacts.zip"
 
       - name: Create draft release
-        run: make -f .ci/Makefile draft-release
+        run: echo "make -f .ci/Makefile draft-release"
 
       - name: Verify draft release
-        run: ORIGINAL_PACKAGES_LOCATION=${{ env.BUILD_PACKAGES }} make -f .ci/Makefile download-verify
+        run: echo "ORIGINAL_PACKAGES_LOCATION=${{ env.BUILD_PACKAGES }} make -f .ci/Makefile download-verify"
 
       - name: Publish release
-        run: make -f .ci/Makefile github-release-ready
+        run: echo "make -f .ci/Makefile github-release-ready"
 
   notify:
     if: always()
@@ -155,5 +154,5 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-php"
+          slackChannel: "#on-week-oblt-productivity"
           message: "[${{ github.repository }}] Release (<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}|${{ github.ref_name }}>)"

```

</p>
</details>


[This build](https://github.com/elastic/apm-agent-php/actions/runs/6169496518) is the one verifying this PR will work as expected.

A slack message is created like the below one (bear in mind, it uses the ref, in this case the test branch, but it will be a tag when merged)

<img width="837" alt="image" src="https://github.com/elastic/apm-agent-php/assets/2871786/71deebe7-4c55-4246-b002-68155574354c">

