### PR TITLE
Fixed exception handling by improving memory allocation and proper exception object copy (#1075)

### DIFF
--- a/agent/native/ext/elastic_apm.cpp
+++ b/agent/native/ext/elastic_apm.cpp
@@ -290,8 +290,6 @@ static PHP_GSHUTDOWN_FUNCTION(elastic_apm) {
     if (elastic_apm_globals->globals) {
         delete elastic_apm_globals->globals;
     }
-    zval_ptr_dtor(&elastic_apm_globals->lastException);
-    ZVAL_UNDEF(&elastic_apm_globals->lastException);
 }
 
 PHP_MINIT_FUNCTION(elastic_apm)
@@ -719,7 +717,7 @@ zend_module_entry elastic_apm_module_entry = {
 	PHP_MODULE_GLOBALS(elastic_apm), /* PHP_MODULE_GLOBALS */
     PHP_GINIT(elastic_apm), 	     /* PHP_GINIT */
     PHP_GSHUTDOWN(elastic_apm),		 /* PHP_GSHUTDOWN */
-	NULL,                            /* post deactivate */
+	elasticApmRequestPostDeactivate, /* post deactivate */
 	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */

--- a/agent/native/ext/elastic_apm.cpp
+++ b/agent/native/ext/elastic_apm.cpp
@@ -281,6 +281,8 @@ static PHP_GINIT_FUNCTION(elastic_apm)
     } catch (std::exception const &e) {
         ELASTIC_APM_LOG_DIRECT_CRITICAL( "Unable to allocate AgentGlobals. '%s'", e.what());
     }
+
+    ZVAL_UNDEF(&elastic_apm_globals->lastException);
 }
 
 static PHP_GSHUTDOWN_FUNCTION(elastic_apm) {
@@ -288,6 +290,8 @@ static PHP_GSHUTDOWN_FUNCTION(elastic_apm) {
     if (elastic_apm_globals->globals) {
         delete elastic_apm_globals->globals;
     }
+    zval_ptr_dtor(&elastic_apm_globals->lastException);
+    ZVAL_UNDEF(&elastic_apm_globals->lastException);
 }
 
 PHP_MINIT_FUNCTION(elastic_apm)

--- a/agent/native/ext/lifecycle.cpp
+++ b/agent/native/ext/lifecycle.cpp
@@ -848,6 +848,10 @@ ZEND_RESULT_CODE  elasticApmRequestPostDeactivate(void) {
 #else
 int  elasticApmRequestPostDeactivate(void) {
 #endif
+    if (!ELASTICAPM_G(globals)->sapi_.isSupported()) {
+        return SUCCESS;
+    }
+
     ELASTIC_APM_LOG_DEBUG_FUNCTION_ENTRY();
 
     if (requestCounter == 1 && detectOpcachePreload()) {

--- a/agent/native/ext/lifecycle.h
+++ b/agent/native/ext/lifecycle.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "main/php_version.h"
+#include "Zend/zend_types.h"
 #include "ResultCode.h"
 
 void elasticApmModuleInit( int moduleType, int moduleNumber );
@@ -26,6 +28,11 @@ void elasticApmModuleShutdown( int moduleType, int moduleNumber );
 
 void elasticApmRequestInit();
 void elasticApmRequestShutdown();
+#if PHP_VERSION_ID >= 80000
+ZEND_RESULT_CODE  elasticApmRequestPostDeactivate(void);
+#else
+int  elasticApmRequestPostDeactivate(void);
+#endif
 
 struct _zval_struct;
 typedef struct _zval_struct zval;

--- a/agent/native/ext/php_elastic_apm.h
+++ b/agent/native/ext/php_elastic_apm.h
@@ -40,6 +40,7 @@ ZEND_TSRMLS_CACHE_EXTERN()
 ZEND_BEGIN_MODULE_GLOBALS(elastic_apm)
     Tracer globalTracer;
     elasticapm::php::AgentGlobals *globals;
+    zval lastException;
 ZEND_END_MODULE_GLOBALS(elastic_apm)
 
 ZEND_EXTERN_MODULE_GLOBALS(elastic_apm)

--- a/agent/native/libcommon/code/PeriodicTaskExecutor.h
+++ b/agent/native/libcommon/code/PeriodicTaskExecutor.h
@@ -112,7 +112,7 @@ private:
 
    void shutdown() {
         thread_.request_stop();
-        pauseCondition_.notify_all();
+        pauseCondition_.notify_one();
    }
 
 private:

--- a/agent/native/libcommon/code/PeriodicTaskExecutor.h
+++ b/agent/native/libcommon/code/PeriodicTaskExecutor.h
@@ -112,7 +112,7 @@ private:
 
    void shutdown() {
         thread_.request_stop();
-        pauseCondition_.notify_one();
+        pauseCondition_.notify_all();
    }
 
 private:

--- a/agent/native/libcommon/test/InferredSpansTest.cpp
+++ b/agent/native/libcommon/test/InferredSpansTest.cpp
@@ -66,6 +66,7 @@ TEST_F(InferredSpansTest, TryInterruptOnlyOnce) {
 TEST_F(InferredSpansTest, DontInterruptBeforeInterval) {
     inferredSpans_.setInterval(10min);
 
+    ::testing::InSequence s;
     EXPECT_CALL(interruptFuncMock_, interruptFunction()).Times(::testing::Exactly(1));
     inferredSpans_.tryRequestInterrupt(std::chrono::time_point_cast<std::chrono::milliseconds>(InferredSpans::clock_t::now()));
 


### PR DESCRIPTION
Moved last exception storage from process globals into PHP's TLS. It is much more safe and will make easier support for thread safe editions of PHP. 

Fixes #1075 