### PR TITLE
add kubernetes data

### DIFF
--- a/agent/php/ElasticApm/Impl/KubernetesData.php
+++ b/agent/php/ElasticApm/Impl/KubernetesData.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Elastic\Apm\Impl;
+
+use Elastic\Apm\Impl\BackendComm\SerializationUtil;
+use Elastic\Apm\Impl\Log\LoggableInterface;
+use Elastic\Apm\Impl\Log\LoggableTrait;
+
+/**
+ * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
+ *
+ * @internal
+ */
+class KubernetesData implements SerializableDataInterface, LoggableInterface
+{
+    use LoggableTrait;
+
+    /**
+     * @var string|null
+     *
+     * Kubernetes namespace.
+     *
+     * The length of this string is limited to 1024.
+     *
+     * @link https://github.com/elastic/apm-server/blob/v7.4.0/docs/spec/system.json#L43
+     */
+    public $namespace = null;
+
+    /**
+     * @var string|null
+     *
+     * Kubernetes pod name.
+     *
+     * The length of this string is limited to 1024.
+     *
+     * @link https://github.com/elastic/apm-server/blob/v7.4.0/docs/spec/system.json#L50
+     */
+    public $podName = null;
+
+    /**
+     * @var string|null
+     *
+     * Kubernetes pod uid.
+     *
+     * The length of this string is limited to 1024.
+     *
+     * @link https://github.com/elastic/apm-server/blob/v7.4.0/docs/spec/system.json#L55
+     */
+    public $podUid = null;
+
+    /**
+     * @var string|null
+     *
+     * Kubernetes node name.
+     *
+     * The length of this string is limited to 1024.
+     *
+     * @link https://github.com/elastic/apm-server/blob/v7.4.0/docs/spec/system.json#L64
+     */
+    public $nodeName = null;
+
+    /** @inheritDoc */
+    public function jsonSerialize()
+    {
+        $result = [];
+
+        SerializationUtil::addNameValueIfNotNull('namespace', $this->namespace, /* ref */ $result);
+
+        if ($this->podName !== null || $this->podUid !== null) {
+            $podSubObject = ['name' => $this->podName, 'uid' => $this->podUid];
+            SerializationUtil::addNameValue('pod', $podSubObject, /* ref */ $result);
+        }
+
+        if ($this->nodeName !== null) {
+            $nodeSubObject = ['name' => $this->nodeName];
+            SerializationUtil::addNameValue('node', $nodeSubObject, /* ref */ $result);
+        }
+
+        return SerializationUtil::postProcessResult($result);
+    }
+}

--- a/agent/php/ElasticApm/Impl/SystemData.php
+++ b/agent/php/ElasticApm/Impl/SystemData.php
@@ -96,6 +96,13 @@ class SystemData implements SerializableDataInterface, LoggableInterface
     public $containerId = null;
 
     /**
+     * @var KubernetesData|null
+     *
+     * @link https://github.com/elastic/apm-server/blob/v7.4.0/docs/spec/system.json#L41
+     */
+    public $kubernetes = null;
+
+    /**
      * @var string|null
      *
      * The length of this string is limited to 1024.
@@ -122,6 +129,7 @@ class SystemData implements SerializableDataInterface, LoggableInterface
 
         SerializationUtil::addNameValueIfNotNull('architecture', $this->architecture, /* ref */ $result);
         SerializationUtil::addNameValueIfNotNull('platform', $this->platform, /* ref */ $result);
+        SerializationUtil::addNameValueIfNotNull('kubernetes', $this->kubernetes, /* ref */ $result);
 
         return SerializationUtil::postProcessResult($result);
     }

--- a/tests/ElasticApmTests/Util/MetadataExpectations.php
+++ b/tests/ElasticApmTests/Util/MetadataExpectations.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace ElasticApmTests\Util;
 
+use Elastic\Apm\Impl\KubernetesData;
 use Elastic\Apm\Impl\NameVersionData;
 
 final class MetadataExpectations extends EventExpectations
@@ -46,6 +47,9 @@ final class MetadataExpectations extends EventExpectations
 
     /** @var Optional<?array<string|bool|int|float|null>> */
     public static $labelsDefault;
+
+    /** @var Optional<?KubernetesData> */
+    public $kubernetes;
 
     /** @var Optional<?string> */
     public $platform;
@@ -97,6 +101,7 @@ final class MetadataExpectations extends EventExpectations
         $this->containerId = new Optional();
         $this->detectedHostname = new Optional();
         $this->labels = self::$labelsDefault;
+        $this->kubernetes = new Optional();
         $this->platform = new Optional();
         $this->serviceEnvironment = new Optional();
         $this->serviceFramework = self::$serviceFrameworkDefault;

--- a/tests/ElasticApmTests/Util/MetadataValidator.php
+++ b/tests/ElasticApmTests/Util/MetadataValidator.php
@@ -201,6 +201,7 @@ final class MetadataValidator
         TestCaseBase::assertSameExpectedOptional($this->expectations->architecture, $this->actual->system->architecture);
         TestCaseBase::assertSameExpectedOptional($this->expectations->platform, $this->actual->system->platform);
         TestCaseBase::assertSameExpectedOptional($this->expectations->containerId, $this->actual->system->containerId);
+        TestCaseBase::assertSameExpectedOptional($this->expectations->kubernetes, $this->actual->system->kubernetes);
     }
 
     public static function verifyHostnames(?string $expectedConfiguredHostname, ?string $expectedDetectedHostname, SystemData $systemData): void


### PR DESCRIPTION
Partialy implements https://github.com/elastic/apm-agent-php/issues/64. Adds [metadata.system.kubernetes](https://github.com/elastic/apm-server/blob/7.0/docs/spec/system.json#L31) filled via environment variables (using Downward API).