### PR TITLE
Use environment variables passed via FastCGI

### DIFF
--- a/agent/php/ElasticApm/Impl/Config/EnvVarsRawSnapshotSource.php
+++ b/agent/php/ElasticApm/Impl/Config/EnvVarsRawSnapshotSource.php
@@ -54,10 +54,7 @@ final class EnvVarsRawSnapshotSource implements RawSnapshotSourceInterface
         $optionNameToEnvVarValue = [];
 
         foreach ($optionNameToMeta as $optionName => $optionMeta) {
-            $envVarValue = getenv(
-                self::optionNameToEnvVarName($this->envVarNamesPrefix, $optionName),
-                /* local_only: */ true
-            );
+            $envVarValue = getenv(self::optionNameToEnvVarName($this->envVarNamesPrefix, $optionName));
             if ($envVarValue !== false) {
                 $optionNameToEnvVarValue[$optionName] = $envVarValue;
             }


### PR DESCRIPTION
Allow passing environment variables from Apache to PHP-FPM to be used as Elastic APM PHP agent configuration

[A simple test application](https://github.com/SergeyKleyman/elastic_apm_php_agent_aux/tree/main/issues/config_per_apache_virtual_host)