### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -8,6 +8,9 @@ on:
 env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   build-packages:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build-packages:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -6,6 +6,9 @@ name: build-packages
 on:
   workflow_call: ~
 
+permissions:
+  contents: read
+
 jobs:
   build-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ name: build
 on:
   workflow_call: ~
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build-agent-library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   build:

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -10,6 +10,9 @@ on:
         description: "The matrix"
         value: ${{ jobs.generate-matrix.outputs.include }}
 
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     timeout-minutes: 5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   test-packages:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -20,6 +20,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test-packages:
     timeout-minutes: 120

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   test-packages:

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   report:

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -9,6 +9,10 @@ on:
       - test
     types: [completed]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
