### PR TITLE
github-action: provenance generation

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -35,7 +35,7 @@ jobs:
         run: make -C packaging package
       - name: package info
         run: make -C packaging info
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: package
           path: |

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -23,7 +23,7 @@ jobs:
         run: make -C packaging package
       - name: package info
         run: make -C packaging info
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: package
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ permissions:
 on:
   push:
     tags: [ "v[0-9]+*" ]
+    branches:
+      - main
+      - feature/provenance
 
 env:
   BUILD_PACKAGES: build/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
 
   release-started:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         with:
@@ -41,7 +42,7 @@ jobs:
       BUCKET_NAME: "apm-agent-php"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: package
           path: ${{ env.BUILD_PACKAGES }}
@@ -74,6 +75,7 @@ jobs:
           predefinedAcl: "publicRead"
 
       - id: buildkite
+        if: startsWith(github.ref, 'refs/tags')
         name: Run buildkite pipeline
         uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
         with:
@@ -90,9 +92,11 @@ jobs:
             BUNDLE_URL=https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ steps.upload-file.outputs.uploaded }}
 
   generate-test-packages-matrix:
+    if: startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/generate-matrix.yml
 
   test-packages:
+    if: startsWith(github.ref, 'refs/tags')
     needs:
       - sign
       - generate-test-packages-matrix
@@ -126,12 +130,15 @@ jobs:
           PACKAGE_FILE: "signed-artifacts.zip"
 
       - name: Create draft release
+        if: startsWith(github.ref, 'refs/tags')
         run: make -f .ci/Makefile draft-release
 
       - name: Verify draft release
+        if: startsWith(github.ref, 'refs/tags')
         run: ORIGINAL_PACKAGES_LOCATION=${{ env.BUILD_PACKAGES }} make -f .ci/Makefile download-verify
 
       - name: Publish release
+        if: startsWith(github.ref, 'refs/tags')
         run: make -f .ci/Makefile github-release-ready
 
   notify:
@@ -150,6 +157,7 @@ jobs:
         with:
           needs: ${{ toJSON(needs) }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        if: startsWith(github.ref, 'refs/tags')
         with:
           status: ${{ steps.check.outputs.status }}
           vaultUrl: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
     env:
       BUCKET_NAME: "apm-agent-php"
     permissions:
+      attestations: write
       id-token: write
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   build-packages:
+    permissions:
+      contents: read
+      packages: read
     needs:
       - build
     uses: ./.github/workflows/build-packages.yml
@@ -111,6 +114,9 @@ jobs:
     needs:
       - sign
       - generate-test-packages-matrix
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/test-packages.yml
     with:
       include: ${{ needs.generate-test-packages-matrix.outputs.include }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
     tags: [ "v[0-9]+*" ]
     branches:
       - main
-      - feature/provenance
 
 env:
   BUILD_PACKAGES: build/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,20 @@ jobs:
       - build-packages
     env:
       BUCKET_NAME: "apm-agent-php"
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: package
           path: ${{ env.BUILD_PACKAGES }}
+
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/${{ env.BUILD_PACKAGES }}/*"
 
       ## NOTE: The name of the zip should match the name of the folder to be zipped.
       - name: Prepare packages to be signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: package
           path: ${{ env.BUILD_PACKAGES }}


### PR DESCRIPTION
## What does this PR do?

Enable the provenance for binaries using the [GitHub provenance action](https://github.com/github-early-access/generate-build-provenance).

Enable running the release workflow in dry-run mode for merge commits onto `main`. This will help detecting breaking changes in the release process before running a formal release.

Fix some regression when using the fpm docker image in https://github.com/elastic/apm-agent-php/pull/1145

### Test

I created a test feature branch to test these changes:
- https://github.com/elastic/apm-agent-php/actions/runs/8848218824

and it produced these attestations:
- https://github.com/elastic/apm-agent-php/attestations