### PR TITLE
ci(fix): use docker compose v2 instead of v1

### DIFF
--- a/.ci/env_vars_for_external_services_for_component_tests_on_host.sh
+++ b/.ci/env_vars_for_external_services_for_component_tests_on_host.sh
@@ -11,4 +11,4 @@ export ELASTIC_APM_PHP_TESTS_MYSQL_PORT=43306
 
 dockerComposeCmdFilesPart="-f ${thisScriptDir}/docker-compose_external_services_for_component_tests.yml"
 dockerComposeCmdFilesPart="${dockerComposeCmdFilesPart} -f ${thisScriptDir}/docker-compose_external_services_for_component_tests_on_host.yml"
-export ELASTIC_APM_PHP_TESTS_EXTERNAL_SERVICES_START_CMD="docker-compose ${dockerComposeCmdFilesPart} up -d"
+export ELASTIC_APM_PHP_TESTS_EXTERNAL_SERVICES_START_CMD="docker compose ${dockerComposeCmdFilesPart} up -d"

--- a/.ci/start_external_services_for_component_tests.sh
+++ b/.ci/start_external_services_for_component_tests.sh
@@ -11,7 +11,7 @@ thisScriptDir="$( dirname "${BASH_SOURCE[0]}" )"
 thisScriptDir="$( realpath "${thisScriptDir}" )"
 
 if [ -z "${ELASTIC_APM_PHP_TESTS_EXTERNAL_SERVICES_START_CMD}" ] ; then
-    export ELASTIC_APM_PHP_TESTS_EXTERNAL_SERVICES_START_CMD="docker-compose -f ${thisScriptDir}/docker-compose_external_services_for_component_tests.yml up -d"
+    export ELASTIC_APM_PHP_TESTS_EXTERNAL_SERVICES_START_CMD="docker compose -f ${thisScriptDir}/docker-compose_external_services_for_component_tests.yml up -d"
 fi
 
 run_command_with_timeout_and_retries_args=(--retry-on-error=yes)

--- a/.ci/stop_external_services_for_component_tests.sh
+++ b/.ci/stop_external_services_for_component_tests.sh
@@ -4,4 +4,4 @@ set -xe
 thisScriptDir="$( dirname "${BASH_SOURCE[0]}" )"
 thisScriptDir="$( realpath "${thisScriptDir}" )"
 
-docker-compose -f "${thisScriptDir}/docker-compose_external_services_for_component_tests.yml" down -v --remove-orphans
+docker compose -f "${thisScriptDir}/docker-compose_external_services_for_component_tests.yml" down -v --remove-orphans

--- a/.github/workflows/phpt.yml
+++ b/.github/workflows/phpt.yml
@@ -50,10 +50,10 @@ jobs:
         VERSION=${{ matrix.php-version }}
         VERSION_SHORT=${VERSION//./}
         cd agent/extension_phpt_test
-        docker-compose build elasticsearch apm-server phpt_${VERSION_SHORT}
-        docker-compose up -d elasticsearch apm-server
-        docker-compose run phpt_${VERSION_SHORT}
-        docker-compose stop
+        docker compose build elasticsearch apm-server phpt_${VERSION_SHORT}
+        docker compose up -d elasticsearch apm-server
+        docker compose run phpt_${VERSION_SHORT}
+        docker compose stop
 #        exit 0
     - if: success() || failure()
       name: Change results ownership

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,7 +130,7 @@ If you want to update images used to build native extension, you need to go into
 `Dockerfile_musl` for Linux x86_64 with musl libc implementation and `Dockerfile_glibc` for all other x86_64 distros with glibc implementation.
 Then you need to increment image version in `docker-compose.yml`. Remember to update Dockerfiles for all architectures, if needed. To build new images, you just need to call:
 ```bash
-docker-compose build
+docker compose build
 ```
 It will build images for all supported architectures. As a result you should get summary like this:
 ```bash
@@ -160,7 +160,7 @@ If you want to update images used for testing, you need to go into `packaging/te
 Then you need to increment image version in `docker-compose.yml`.\
 To build new images, you just need to call:
 ```bash
-docker-compose build
+docker compose build
 ```
 It will build and tag images for all test scenarios. As a result you should get summary like this:
 ```bash

--- a/agent/extension_phpt_test/README.md
+++ b/agent/extension_phpt_test/README.md
@@ -25,7 +25,7 @@ To run the tests, you must first build the agent binaries for the `linux-x86-64-
 
 ```
 cd apm-agent-php/agent/extension_phpt_test
-docker-compose up --build
+docker compose up --build
 ```
 
 It will start up elastic search and apm-server and execute tests for all supported PHP releases.
@@ -38,7 +38,7 @@ In this example we will run all tests with PHP 8.2
 
 ```
 cd apm-agent-php/agent/extension_phpt_test
-docker-compose up elasticsearch apm-server phpt_82
+docker compose up elasticsearch apm-server phpt_82
 ```
 It will start up elastic search and apm-server and execute tests for PHP 8.2.
 
@@ -48,8 +48,8 @@ In this example we will run test with PHP 8.2
 
 ```
 cd apm-agent-php/agent/extension_phpt_test
-docker-compose build phpt_82 elasticsearch apm-server
-docker-compose run --rm  phpt_82 /scripts/run.sh tests/output/ob_start_error_005.phpt
+docker compose build phpt_82 elasticsearch apm-server
+docker compose run --rm  phpt_82 /scripts/run.sh tests/output/ob_start_error_005.phpt
 ```
 
 ### Run bunch of tests from a folder
@@ -58,8 +58,8 @@ In this example we will run test with PHP 8.2
 
 ```
 cd apm-agent-php/agent/extension_phpt_test
-docker-compose build phpt_82 elasticsearch apm-server
-docker-compose run --rm  phpt_82 /scripts/run.sh tests/output
+docker compose build phpt_82 elasticsearch apm-server
+docker compose run --rm  phpt_82 /scripts/run.sh tests/output
 ```
 
 ### Core dump examination with gdb
@@ -68,7 +68,7 @@ In order to diagnose a core dump, you need to run the image together with the mo
 
 ```
 cd apm-agent-php/agent/extension_phpt_test
-docker-compose run -v /path/to/coredumps:/path/to/coredumps phpt_82 /bin/bash
+docker compose run -v /path/to/coredumps:/path/to/coredumps phpt_82 /bin/bash
 ```
 then inside runnning container:
 ```

--- a/agent/extension_phpt_test/scripts/run.sh
+++ b/agent/extension_phpt_test/scripts/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # if you want to run only that one test, execute scipt with test or folder name
-# example: docker-compose run --rm  phpt_82 /scripts/run.sh tests/output
-# example: docker-compose run --rm  phpt_82 /scripts/run.sh tests/output/ob_start_error_005.phpt
+# example: docker compose run --rm  phpt_82 /scripts/run.sh tests/output
+# example: docker compose run --rm  phpt_82 /scripts/run.sh tests/output/ob_start_error_005.phpt
 TEST_OR_DIRECTORY_TO_EXECUTE=$1
 
 PHP_VERSION=`php-config --version`
@@ -24,7 +24,7 @@ elif [ $PHP_VERSION == "8.2" ]; then
 fi
 
 mkdir -m 666 -p /results/${PHP_VERSION}
-echo "Making results directory /results/${PHP_VERSION} resultCode: $?" 
+echo "Making results directory /results/${PHP_VERSION} resultCode: $?"
 
 RESULT_PREFIX=`date -u +"%Y%m%d_%H%M%S-"`
 

--- a/demos/CakePHP/README.md
+++ b/demos/CakePHP/README.md
@@ -3,8 +3,8 @@
 Set up application.
 
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 After it open the next link
 ```

--- a/demos/Codeigniter/README.md
+++ b/demos/Codeigniter/README.md
@@ -3,8 +3,8 @@
 Setup application.
 
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 
 Application url:

--- a/demos/Laminas/README.md
+++ b/demos/Laminas/README.md
@@ -3,8 +3,8 @@
 Setup application with the next commands.
 
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 
 Application url:

--- a/demos/Laminas/public/index.php
+++ b/demos/Laminas/public/index.php
@@ -34,7 +34,7 @@ if (! class_exists(Application::class)) {
         "Unable to load application.\n"
         . "- Type `composer install` if you are developing locally.\n"
         . "- Type `vagrant ssh -c 'composer install'` if you are using Vagrant.\n"
-        . "- Type `docker-compose run laminas composer install` if you are using Docker.\n"
+        . "- Type `docker compose run laminas composer install` if you are using Docker.\n"
     );
 }
 
@@ -75,7 +75,7 @@ Application::init($appConfig)->run();
 //        "Unable to load application.\n"
 //        . "- Type `composer install` if you are developing locally.\n"
 //        . "- Type `vagrant ssh -c 'composer install'` if you are using Vagrant.\n"
-//        . "- Type `docker-compose run laminas composer install` if you are using Docker.\n"
+//        . "- Type `docker compose run laminas composer install` if you are using Docker.\n"
 //    );
 //}
 //

--- a/demos/Magento/README-ELASTIC.md
+++ b/demos/Magento/README-ELASTIC.md
@@ -1,7 +1,7 @@
 # How to set up ?
 ```
-1. docker-compose build
-2. docker-compose up
+1. docker compose build
+2. docker compose up
 ```
 
 1. Fronted:

--- a/demos/Magento/README.md
+++ b/demos/Magento/README.md
@@ -12,7 +12,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 ```console
 $ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-magento/master/docker-compose.yml > docker-compose.yml
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 **Warning**: This quick setup is only intended for development environments. You are encouraged to change the insecure default credentials and check out the available configuration options in the [Environment Variables](#environment-variables) section for a more secure deployment.
@@ -71,7 +71,7 @@ The main folder of this repository contains a functional [`docker-compose.yml`](
 
 ```console
 $ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-magento/master/docker-compose.yml > docker-compose.yml
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 ### Using the Docker Command Line
@@ -225,9 +225,9 @@ When the container is executed for the first time, it will execute the files wit
 
 ### Environment variables
 
-When you start the Magento image, you can adjust the configuration of the instance by passing one or more environment variables either on the docker-compose file or on the `docker run` command line. If you want to add a new environment variable:
+When you start the Magento image, you can adjust the configuration of the instance by passing one or more environment variables either on the docker compose file or on the `docker run` command line. If you want to add a new environment variable:
 
- * For docker-compose add the variable name and value under the application section in the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-magento/blob/master/docker-compose.yml) file present in this repository:
+ * For docker compose add the variable name and value under the application section in the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-magento/blob/master/docker-compose.yml) file present in this repository:
 
 ```yaml
 magento:
@@ -345,7 +345,7 @@ $ docker logs magento
 Or using Docker Compose:
 
 ```console
-$ docker-compose logs magento
+$ docker compose logs magento
 ```
 
 You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
@@ -365,7 +365,7 @@ $ docker stop magento
 Or using Docker Compose:
 
 ```console
-$ docker-compose stop magento
+$ docker compose stop magento
 ```
 
 #### Step 2: Run the backup command
@@ -505,7 +505,7 @@ $ docker stop magento
 Or using Docker Compose:
 
 ```console
-$ docker-compose stop magento
+$ docker compose stop magento
 ```
 
 #### Upgrading bundled image components
@@ -523,7 +523,7 @@ $ docker pull bitnami/magento:latest
 Stop the currently running container using the command
 
 ```console
-$ docker-compose stop magento
+$ docker compose stop magento
 ```
 
 ##### Step 3: Take a snapshot of the application state
@@ -535,7 +535,7 @@ Follow the steps in [Backing up your container](#backing-up-your-container) to t
 Remove the currently running container by executing the following command:
 
 ```console
-docker-compose rm -v magento
+docker compose rm -v magento
 ```
 
 ##### Step 5: Run the new image
@@ -543,7 +543,7 @@ docker-compose rm -v magento
 Update the image tag in `docker-compose.yml` and re-create your container with the new image:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 ## Customize this image

--- a/demos/Shopware/README.md
+++ b/demos/Shopware/README.md
@@ -94,7 +94,7 @@ When you update the image version, automatically all required migrations will ru
 
 # Running multiple containers
 
-See `docker-compose-advanced.yml` for a full docker-compose example.
+See `docker-compose-advanced.yml` for a full docker compose example.
 
 ## Mode: default
 

--- a/demos/Shopware/README_ELASTIC.md
+++ b/demos/Shopware/README_ELASTIC.md
@@ -1,7 +1,7 @@
 # How to set up ?
 ```
-1. docker-compose build
-2. docker-compose up
+1. docker compose build
+2. docker compose up
 ```
 
 1. Fronted:

--- a/demos/Symfony/README.md
+++ b/demos/Symfony/README.md
@@ -3,8 +3,8 @@
 Set up application.
 
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 After it open the next link
 ```

--- a/demos/WordPress/README.md
+++ b/demos/WordPress/README.md
@@ -3,5 +3,5 @@
 Setup application with a single command.
 
 ```
-$ docker-compose up
+$ docker compose up
 ```

--- a/demos/Yii2/README.md
+++ b/demos/Yii2/README.md
@@ -86,15 +86,15 @@ http://localhost/basic/web/
 
 Update your vendor packages
 
-    docker-compose run --rm php composer update --prefer-dist
+    docker compose run --rm php composer update --prefer-dist
     
 Run the installation triggers (creating cookie validation code)
 
-    docker-compose run --rm php composer install    
+    docker compose run --rm php composer install    
     
 Start the container
 
-    docker-compose up -d
+    docker compose up -d
     
 You can then access the application through the following URL:
 

--- a/demos/Yii2/README_ELASTIC.md
+++ b/demos/Yii2/README_ELASTIC.md
@@ -3,8 +3,8 @@
 Set up application.
 
 ```
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 After it open the next link
 ```


### PR DESCRIPTION
## What is the change being made?

* Use docker compose v2 instead of v1.

## Why is the change being made?

* Github removed docker-compose v1 support from Runner image on 1st April 2024.
* https://github.com/actions/runner-images/blob/ubuntu22/20240401.4/images/ubuntu/Ubuntu2204-Readme.md