### PR TITLE
ci: allow running the signing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
           predefinedAcl: "publicRead"
 
       - id: buildkite-run
-        if: startsWith(github.ref, 'refs/tags')
         uses: elastic/oblt-actions/buildkite/run@v1.8.0
         with:
           token: ${{ secrets.BUILDKITE_TOKEN }}


### PR DESCRIPTION
Otherwise, the download artifacts from Buildkite won't work.

There is no issue to run the buildkite sign pipeline as it does nothing but sign the artifacts


### Test

`test/release-sign-branches` has been created and its workflow is running:
- https://github.com/elastic/apm-agent-php/actions/runs/9389991481