### PR TITLE
github-secrets: use keyless

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,21 +64,6 @@ jobs:
         run: zip -r packages.zip packages/
         working-directory: build
 
-      - name: 'Get service account'
-        uses: hashicorp/vault-action@v3.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          method: approle
-          secrets: |
-            secret/observability-team/ci/apm-agent-php-bucket service-account | SERVICE_ACCOUNT ;
-
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: '${{ env.SERVICE_ACCOUNT }}'
-
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           path: "${{ env.BUILD_PACKAGES }}.zip"
           destination: "${{ env.BUCKET_NAME }}/${{ github.run_id }}"
-          predefinedAcl: "publicRead"
 
       - id: buildkite-run
         uses: elastic/oblt-actions/buildkite/run@v1.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
         run: zip -r packages.zip packages/
         working-directory: build
 
+      - uses: elastic/oblt-actions/google/auth@v1.9.3
+
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
         working-directory: build
 
       - uses: elastic/oblt-actions/google/auth@v1.9.3
+        with:
+          project-number: '911195782929'
 
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v2'


### PR DESCRIPTION
Use Keyless access.

Test -> https://github.com/elastic/apm-agent-php/actions/runs/9585060144

<img width="1048" alt="image" src="https://github.com/elastic/apm-agent-php/assets/2871786/6805b64c-3e94-4e85-b0b5-ac688dcaf3ea">


There were some failures but all of them have been addressed now:

<details><summary>Expand to view</summary>
<p>


```
Created credentials file at "/home/runner/work/apm-agent-php/apm-agent-php/gha-creds-c42c301e3f0c0e16.json"
Error: google-github-actions/auth failed with: failed to generate Google Cloud federated token for //iam.googleapis.com/projects/911195782929/locations/global/workloadIdentityPools/github/providers/repo-28ae8e252eba0f7b95257e8cb2c: {"error":"invalid_target","error_description":"The target service indicated by the \"audience\" parameters is invalid. This might either be because the pool or provider is disabled or deleted or because it doesn't exist."}
```


```
  Error: google-github-actions/upload-cloud-storage failed with: {"code":412,"message":"The type of authentication token used for this request requires that Uniform Bucket Level Access be enabled.","errors":[{"message":"The type of authentication token used for this request requires that Uniform Bucket Level Access be enabled.","domain":"global","reason":"conditionNotMet","locationType":"header","location":"If-Match"}]}
```


```
$ gsutil uniformbucketlevelaccess set on gs://apm-agent-php
Enabling Uniform bucket-level access for gs://apm-agent-php...
```

</p>
</details>
