### PR TITLE
github-actions: use ephemeral tokens

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, edited, milestoned]
   pull_request_target:
     types: [opened, edited, milestoned]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
 permissions:
   contents: read
@@ -16,6 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign milestoned to Project
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "issues": "read",
+            "organization_projects": "write",
+            "pull_requests": "read"
+          }
     - name: Assign issues with milestones to project
       uses: elastic/assign-one-project-github-action@1.2.2
       if: github.event.issue && github.event.issue.milestone
@@ -23,6 +33,8 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'Planned'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
     - name: Assign new pull requests to project
       uses: elastic/assign-one-project-github-action@1.2.2
       if: github.event.action == 'opened' && github.event.pull_request
@@ -30,3 +42,5 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'In Progress'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
Use GH app for creating ephemeral tokens instead of using a finer-grained token

