### PR TITLE
github-action: use elastic/oblt-actions/check-dependent-jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: check
-        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
-          needs: ${{ toJSON(needs) }}
+          jobs: ${{ toJSON(needs) }}
       - if: startsWith(github.ref, 'refs/tags')
         uses: elastic/oblt-actions/slack/notify-result@v1.8.0
         with:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been archived in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/16 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
