### PR TITLE
github-actions: use v1 for the oblt-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: elastic/oblt-actions/slack/send@v1.8.0
+      - uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-php"
@@ -67,7 +67,7 @@ jobs:
         run: zip -r packages.zip packages/
         working-directory: build
 
-      - uses: elastic/oblt-actions/google/auth@v1.9.3
+      - uses: elastic/oblt-actions/google/auth@v1
         with:
           project-number: '911195782929'
 
@@ -78,7 +78,7 @@ jobs:
           destination: "${{ env.BUCKET_NAME }}/${{ github.run_id }}"
 
       - id: buildkite-run
-        uses: elastic/oblt-actions/buildkite/run@v1.8.0
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
           token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: observability-robots-php-release
@@ -86,7 +86,7 @@ jobs:
           env-vars: |
             BUNDLE_URL=https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ steps.upload-file.outputs.uploaded }}
 
-      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.8.0
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
           build-number: ${{ steps.buildkite-run.outputs.number }}
           path: signed-artifacts.zip
@@ -170,7 +170,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
       - if: startsWith(github.ref, 'refs/tags')
-        uses: elastic/oblt-actions/slack/notify-result@v1.8.0
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-php"


### PR DESCRIPTION
dependabot does not bump versions for GitHub action using semver and `v1`, see https://github.com/dependabot/dependabot-core/issues/10924