### PR TITLE
Include createErrorFromThrowable

### DIFF
--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -47,6 +47,28 @@ try {
 
 See [TransactionInterface](#api-transaction-interface) on how to customize a transaction.
 
+### `ElasticApm::createErrorFromThrowable` [api-elasticapm-class-create-error-from-throwable]
+
+Captures a throwable exception. This API:
+* Captures an error as an exception
+* Displays it in the ElasticAPM `Errors` screen
+* Allows for easy tracking of caught exceptions.
+
+For example:
+```php
+use Elastic\Apm\ElasticApm;
+
+private function captureExceptionFromErrorMessage($message)
+{
+    try {
+        throw new Exception($message);
+    } catch (Throwable $ex) {
+        ElasticApm::createErrorFromThrowable($ex);
+    }
+}
+```
+
+The code above would allow for an error message, along with its stack trace to be monitored.
 
 ### `ElasticApm::captureCurrentTransaction` [api-elasticapm-class-capture-current-transaction]
 


### PR DESCRIPTION
createErrorFromThrowable has been helpful for our team to make a migration away from Sentry towards ElasticAPM.

Adding it to documentation will assist users making the decision to make the move from other methods of monitoring