### PR TITLE
Fix `Failed to fetch` error

### DIFF
--- a/packaging/test/ubuntu/Dockerfile
+++ b/packaging/test/ubuntu/Dockerfile
@@ -4,6 +4,7 @@ ARG SEL_DISTRO=buster
 FROM php:${PHP_VERSION}-fpm-${SEL_DISTRO}
 
 RUN apt-get -qq update \
+    && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \
         dpkg-sig \
         gnupg \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -23,10 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with apache2
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN add-apt-repository ppa:ondrej/php \
+RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
-    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install apt-utils \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
+    && apt-get -qq -y --no-install-recommends install apt-utils \
         dpkg-sig \
         git \
         gnupg \
@@ -23,9 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with apache2
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+RUN apt-get -qq update \
+    && apt-get -qq -y --no-install-recommends install apt-transport-https \
+    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && add-apt-repository ppa:ondrej/php \
-    && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -23,10 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with apache2
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq update \
+RUN add-apt-repository ppa:ondrej/php \
+    && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -23,11 +23,9 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with apache2
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install software-properties-common \
+RUN apt-get -qq -y --no-install-recommends install software-properties-common \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -24,7 +24,7 @@ COPY entrypoint.sh /bin
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
 RUN apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository ppa:ondrej/php \
+    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -25,7 +25,7 @@ ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
 RUN apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
+    && add-apt-repository -y ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -23,7 +23,8 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with apache2
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+RUN apt-get -qq update \
+    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \

--- a/packaging/test/ubuntu/apache/Dockerfile
+++ b/packaging/test/ubuntu/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
@@ -24,7 +24,7 @@ COPY entrypoint.sh /bin
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
 RUN apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository -y ppa:ondrej/php \
+    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -23,9 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with fpm and apache
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+RUN apt-get -qq update \
+    && apt-get -qq -y --no-install-recommends install apt-transport-https \
+    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && add-apt-repository ppa:ondrej/php \
-    && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install apt-utils \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
+    && apt-get -qq -y --no-install-recommends install apt-utils \
         dpkg-sig \
         git \
         gnupg \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -23,11 +23,9 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with fpm and apache
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository -y ppa:ondrej/php \
+RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
-    && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -24,7 +24,7 @@ COPY entrypoint.sh /bin
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
 RUN apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository ppa:ondrej/php \
+    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -23,10 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with fpm and apache
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN add-apt-repository ppa:ondrej/php \
+RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
-    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -25,7 +25,7 @@ ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
 RUN apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
+    && add-apt-repository -y ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -23,10 +23,10 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with fpm and apache
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq update \
+RUN add-apt-repository ppa:ondrej/php \
+    && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \
     && apt-get -qq -y --no-install-recommends install software-properties-common \
-    && add-apt-repository ppa:ondrej/php \
     && apt-get -qq -y --no-install-recommends install \
         apache2 \
         php${PHP_VERSION} \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -23,7 +23,8 @@ COPY entrypoint.sh /bin
 ## Install the specific PHP version in addition with fpm and apache
 ARG PHP_VERSION=7.2
 ENV PHP_VERSION=$PHP_VERSION
-RUN apt-get -qq -y --no-install-recommends install software-properties-common \
+RUN apt-get -qq update \
+    && apt-get -qq -y --no-install-recommends install software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-transport-https \

--- a/packaging/test/ubuntu/fpm/Dockerfile
+++ b/packaging/test/ubuntu/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \


### PR DESCRIPTION
Discovered in: https://github.com/elastic/apm-agent-php/actions/runs/15380322429/job/43270374982#step:11:176
Tests fail with: `Failed to fetch error` and `Unable to locate package php****`

To solve `Failed to fetch error`: moved `apt-transport-https` before the `apt-utils` installation to fix errors. 
To solve `Unable to locate package php****`: update the image to Ubuntu 22.04, since 20.04 is EOL (https://github.com/oerdnj/deb.sury.org/issues/2243).