### PR TITLE
Add applies_to metadata

### DIFF
--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/configuration-reference.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Configuration reference [configuration-reference]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/configuration.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Configuration [configuration]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,16 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/intro.html
   - https://www.elastic.co/guide/en/apm/agent/php/current/index.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # APM PHP agent [intro]

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/public-api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Public API [public-api]

--- a/docs/reference/set-up-apm-php-agent.md
+++ b/docs/reference/set-up-apm-php-agent.md
@@ -2,6 +2,16 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/setup.html
   - https://www.elastic.co/guide/en/apm/agent/php/current/_limitations.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Set up the APM PHP Agent [setup]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/supported-technologies.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Supported technologies [supported-technologies]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -32,6 +32,16 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/php/current/release-notes-v1.0.1.html
   - https://www.elastic.co/guide/en/apm/agent/php/current/release-notes-v1.0.html
   - https://www.elastic.co/guide/en/apm/agent/php/current/release-notes-v1.0.0-beta1.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM PHP Agent release notes [elastic-apm-php-agent-release-notes]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,15 @@
 ---
 navigation_title: "Known issues"
-
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_php: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM PHP Agent known issues [elastic-apm-php-agent-known-issues]


### PR DESCRIPTION
Adds ` applies_to` metadata for cumulative docs. See https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies

Contributes to https://github.com/elastic/docs-content-internal/issues/253