### PR TITLE
Capture ALL uncaught exceptions as exceptions

### DIFF
--- a/agent/php/ElasticApm/Impl/AutoInstrument/TransactionForExtensionRequest.php
+++ b/agent/php/ElasticApm/Impl/AutoInstrument/TransactionForExtensionRequest.php
@@ -383,7 +383,7 @@ final class TransactionForExtensionRequest
         if (
             $this->lastThrown !== null
             && $phpErrorData->message !== null
-            && TextUtil::isPrefixOf('Uncaught Exception: ', $phpErrorData->message, /* isCaseSensitive: */ false)
+            && TextUtil::isPrefixOf('Uncaught ' . get_class($this->lastThrown) . ':', $phpErrorData->message, /* isCaseSensitive: */ false)
         ) {
             $relatedThrowable = $this->lastThrown;
             $this->lastThrown = null;

--- a/tests/ElasticApmTests/ComponentTests/ErrorComponentTest.php
+++ b/tests/ElasticApmTests/ComponentTests/ErrorComponentTest.php
@@ -539,4 +539,116 @@ final class ErrorComponentTest extends ComponentTestCaseBase
             }
         );
     }
+
+    public static function appCodeForTestPhpErrorUncaughtExceptionSubclassWrapper(bool $justReturnLineNumber = false): int
+    {
+        if (!$justReturnLineNumber) {
+            ini_set('display_errors', '0');
+        }
+
+        return $justReturnLineNumber ? __LINE__ : appCodeForTestPhpErrorUncaughtExceptionSubclass();
+    }
+
+    private function implTestPhpErrorUncaughtExceptionSubclass(MixedMap $testArgs): void
+    {
+        AssertMessageStack::newScope(/* out */ $dbgCtx, AssertMessageStack::funcArgs());
+
+        $captureErrorsOptVal = $testArgs->getBool(OptionNames::CAPTURE_ERRORS);
+        $captureErrorsWithPhpPartOptVal = $testArgs->getBool(OptionNames::CAPTURE_ERRORS_WITH_PHP_PART);
+        $captureExceptionsOptVal = $testArgs->getNullableBool(OptionNames::CAPTURE_EXCEPTIONS);
+        $shouldCaptureExceptionsDerivedCfg = $captureExceptionsOptVal ?? $captureErrorsOptVal;
+        $devInternalCaptureErrorsOnlyToLogOptVal = $testArgs->getBool(OptionNames::DEV_INTERNAL_CAPTURE_ERRORS_ONLY_TO_LOG);
+
+        $testCaseHandle = $this->getTestCaseHandle();
+        $appCodeHost = self::ensureMainAppCodeHost($testCaseHandle, $testArgs);
+
+        $appCodeHost->sendRequest(
+            AppCodeTarget::asRouted([__CLASS__, 'appCodeForTestPhpErrorUncaughtExceptionSubclassWrapper']),
+            function (AppCodeRequestParams $appCodeRequestParams): void {
+                if ($appCodeRequestParams instanceof HttpAppCodeRequestParams) {
+                    $appCodeRequestParams->expectedHttpResponseStatusCode = HttpConstantsForTests::STATUS_INTERNAL_SERVER_ERROR;
+                }
+            }
+        );
+
+        if ($captureErrorsWithPhpPartOptVal) {
+            $isErrorExpected = $shouldCaptureExceptionsDerivedCfg;
+        } else {
+            if (self::isMainAppCodeHostHttp()) {
+                $isErrorExpected = $captureErrorsOptVal || $shouldCaptureExceptionsDerivedCfg;
+            } else {
+                $isErrorExpected = $captureErrorsOptVal;
+            }
+        }
+        $isErrorExpected = $isErrorExpected && !$devInternalCaptureErrorsOnlyToLogOptVal;
+
+        $expectedErrorCount = $isErrorExpected ? 1 : 0;
+        $dataFromAgent = $testCaseHandle->waitForDataFromAgent((new ExpectedEventCounts())->transactions(1)->errors($expectedErrorCount));
+        $dbgCtx->add(compact('dataFromAgent'));
+
+        if (self::isMainAppCodeHostHttp()) {
+            self::assertSame(Constants::OUTCOME_FAILURE, $dataFromAgent->singleTransaction()->outcome);
+        }
+
+        self::assertCount($expectedErrorCount, $dataFromAgent->idToError);
+        if (!$isErrorExpected) {
+            return;
+        }
+
+        $err = $this->verifyError($dataFromAgent);
+
+        $appCodeFile = FileUtilForTests::listToPath([dirname(__FILE__), 'appCodeForTestPhpErrorUncaughtException.php']);
+        self::assertNotNull($err->exception);
+        self::assertNull($err->exception->module);
+        if ($shouldCaptureExceptionsDerivedCfg) {
+            $culpritFunction = __NAMESPACE__ . '\\appCodeForTestPhpErrorUncaughtExceptionSubclassImpl';
+            self::assertSame($culpritFunction, $err->culprit);
+
+            $defaultCode = (new \RuntimeException(''))->getCode();
+            self::assertSame($defaultCode, $err->exception->code);
+            self::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_MESSAGE, $err->exception->message);
+            self::assertSame('RuntimeException', $err->exception->type);
+            $expectedStackTraceTop = [
+                [
+                    self::STACK_TRACE_FILE_NAME   => $appCodeFile,
+                    self::STACK_TRACE_FUNCTION    => null,
+                    self::STACK_TRACE_LINE_NUMBER => APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_ERROR_LINE_NUMBER,
+                ],
+                [
+                    self::STACK_TRACE_FILE_NAME   => $appCodeFile,
+                    self::STACK_TRACE_FUNCTION    => __NAMESPACE__ . '\\appCodeForTestPhpErrorUncaughtExceptionSubclassImpl',
+                    self::STACK_TRACE_LINE_NUMBER => APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_CALL_TO_IMPL_LINE_NUMBER,
+                ],
+                [
+                    self::STACK_TRACE_FILE_NAME   => __FILE__,
+                    self::STACK_TRACE_FUNCTION    => __NAMESPACE__ . '\\appCodeForTestPhpErrorUncaughtExceptionSubclass',
+                    self::STACK_TRACE_LINE_NUMBER => self::appCodeForTestPhpErrorUncaughtExceptionSubclassWrapper(/* justReturnLineNumber */ true),
+                ],
+                [
+                    self::STACK_TRACE_FUNCTION => __CLASS__ . '::appCodeForTestPhpErrorUncaughtExceptionSubclassWrapper',
+                ],
+            ];
+            self::verifyAppCodeStackTraceTop($expectedStackTraceTop, $err);
+        } else { // if ($shouldCaptureExceptionsDerivedCfg)
+            self::assertNull($err->culprit);
+
+            self::assertNotNull($err->exception->message);
+            self::assertStringContainsString(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_MESSAGE, $err->exception->message);
+            self::assertNotNull($err->exception->stacktrace);
+            self::assertCount(0, $err->exception->stacktrace);
+        }
+    }
+
+    /**
+     * @dataProvider dataProviderForTestsForErrorCausedByException
+     */
+    public function testPhpErrorUncaughtExceptionSubclass(MixedMap $testArgs): void
+    {
+        self::runAndEscalateLogLevelOnFailure(
+            self::buildDbgDescForTestWithArtgs(__CLASS__, __FUNCTION__, $testArgs),
+            function () use ($testArgs): void {
+                $this->implTestPhpErrorUncaughtExceptionSubclass($testArgs);
+            }
+        );
+    }
 }

--- a/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUncaughtException.php
+++ b/tests/ElasticApmTests/ComponentTests/appCodeForTestPhpErrorUncaughtException.php
@@ -71,3 +71,33 @@ function appCodeForTestPhpErrorUncaughtException(): int
     TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
     appCodeForTestPhpErrorUncaughtExceptionImpl(); // <- APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_CALL_TO_IMPL_LINE_NUMBER
 }
+
+const APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_MESSAGE = 'Message for uncaught RuntimeException subclass';
+
+const APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_ERROR_LINE_NUMBER = 89;
+
+/**
+ * @return never
+ *
+ * @throws \RuntimeException
+ *
+ * @noinspection PhpReturnDocTypeMismatchInspection
+ */
+function appCodeForTestPhpErrorUncaughtExceptionSubclassImpl()
+{
+    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_ERROR_LINE_NUMBER, __LINE__ + 1);
+    throw new \RuntimeException(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_MESSAGE); // <- APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_ERROR_LINE_NUMBER
+}
+
+const APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_CALL_TO_IMPL_LINE_NUMBER = 102;
+
+/**
+ * @return never
+ *
+ * @throws \RuntimeException
+ */
+function appCodeForTestPhpErrorUncaughtExceptionSubclass(): int
+{
+    TestCase::assertSame(APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_CALL_TO_IMPL_LINE_NUMBER, __LINE__ + 1);
+    appCodeForTestPhpErrorUncaughtExceptionSubclassImpl(); // <- APP_CODE_FOR_TEST_PHP_ERROR_UNCAUGHT_EXCEPTION_SUBCLASS_CALL_TO_IMPL_LINE_NUMBER
+}


### PR DESCRIPTION
This PR fixes an issue in the native uncaught exception handling, where only the `\Exception` class was eligible for decomposition into a verbose exception capture, leaving all other Throwables to capture as flat errors.

This change now matches the FQCN of `lastThrown` back to the `Uncaught <FQCN>:` in an effort to capture ALL exception types, and the specifically relevant exception.

## What was happening?

We have some pre-framework code super early which `throws new \RuntimeException(`, and APM was seeing this as a flat error rather than an Exception with a trace, unlike _everything else_ we have going into APM.

This was traced back to the explicit `Uncaught Exception:` prefix test not matching what PHP emits: `Uncaught RuntimeException:`

In APM this becomes an Error with the full stack-trace in the Message, and N/A for the origin function, with no Exception detailing.  In turn, this representation really messes with Error Grouping and causes a lot of duplication in APM.

## Why match the FQCN?

`lastThrown` isn't diligently unset, there's some opportunity for it to be populated when various event handlers get fired. The FQCN comparison is intended to ensure the `lastThrown` is definitely the same Exception mentioned in the native "Uncaught" message.

FQCN matching seems to work for even namespaced throwables: https://3v4l.org/lrIIP#veol
```
namespace Hello\World;
class Derp extends \LogicException {}

$x = new \Hello\World\Derp('hello');
echo get_class($x);
throw $x;

Hello\World\Derp
Fatal error: Uncaught Hello\World\Derp: hello in /in/lrIIP:7
```

## Why hasn't anyone else seen this?

I'd wager that if you're using APM you're probably also using some kind of Framework with its own error-capture, and you'll then be using a library to augment APM with more telemetry, and this goes through a lot of non-php-native-paths to register the Exception with APM (eg. `ElasticApm::createErrorFromThrowable`), and code almost never lets an Exception escape to the native PHP handler.

Only when a non-\Exception type is thrown and truly uncaught, does this kick in.

## Oh god the test case

I didn't want to disrupt the existing uncaught exception test case, so the test case you see added is just a duplication of the existing Uncaught Exception test.  In all honesty this should probably become a dataProvider thing, but I didn't want to make it painful to validate the fix.  Better to add the fix and _then_ refactor the test cases.