### PR TITLE
fix(ci): replace deprecated assign-one-project action with oblt-actions

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -16,31 +16,48 @@ jobs:
     steps:
     - name: Get token
       id: get_token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@v3
       with:
-        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-        permissions: >-
-          {
-            "issues": "read",
-            "organization_projects": "write",
-            "pull_requests": "read"
-          }
-    - name: Assign issues with milestones to project
-      uses: elastic/assign-one-project-github-action@1.2.2
+        app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permission-organization-projects: write
+        permission-issues: read
+        permission-pull-requests: read
+
+    - name: Add milestoned issues to project
+      id: add-issue-to-project
       if: github.event.issue && github.event.issue.milestone
+      uses: elastic/oblt-actions/github/project-add@v1
       with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'Planned'
-      env:
-        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
-    - name: Assign new pull requests to project
-      uses: elastic/assign-one-project-github-action@1.2.2
+        github-token: ${{ steps.get_token.outputs.token }}
+        project-id: 1674
+        item-url: ${{ github.event.issue.html_url }}
+
+    - name: Set issue status to Planned
+      if: github.event.issue && github.event.issue.milestone
+      uses: elastic/oblt-actions/github/project-field-set@v1
+      with:
+        github-token: ${{ steps.get_token.outputs.token }}
+        project-id: 1674
+        item-id: ${{ steps.add-issue-to-project.outputs.item-id }}
+        field-name: Status
+        field-value: Planned
+
+    - name: Add new pull requests to project
+      id: add-pr-to-project
       if: github.event.action == 'opened' && github.event.pull_request
+      uses: elastic/oblt-actions/github/project-add@v1
       with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'In Progress'
-      env:
-        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+        github-token: ${{ steps.get_token.outputs.token }}
+        project-id: 1674
+        item-url: ${{ github.event.pull_request.html_url }}
+
+    - name: Set pull request status to In Progress
+      if: github.event.action == 'opened' && github.event.pull_request
+      uses: elastic/oblt-actions/github/project-field-set@v1
+      with:
+        github-token: ${{ steps.get_token.outputs.token }}
+        project-id: 1674
+        item-id: ${{ steps.add-pr-to-project.outputs.item-id }}
+        field-name: Status
+        field-value: In Progress


### PR DESCRIPTION
## Summary

- Replace the archived `elastic/assign-one-project-github-action@1.2.2` (broken Docker image) with `elastic/oblt-actions/github/project-add@v1` and `github/project-field-set@v1`.
- Migrate GitHub App token creation to `actions/create-github-app-token@v3`.
- Target project **1674** directly (canonical Projects v2 number; replaces HTTP-redirect URL `/454` and legacy classic ID `5882982`).
- Preserve existing behavior: milestoned issues go to project 1674 with Status `Planned`; newly opened PRs go to project 1674 with Status `In Progress`.

## Test plan

- [ ] Merge and verify the `Auto Assign to Project(s)` workflow succeeds on a newly opened PR.
- [ ] Verify a milestoned issue is added to project 1674 with Status `Planned`.

Related issue: https://github.com/elastic/observability-robots/issues/4715